### PR TITLE
Remove torch from required dips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ test:
 install:
 	pip install -e ".[dev]"
 
+install-lite:
+	pip install -e .
+
 download:
 	python policyengine_uk_data/storage/download_private_prerequisites.py
 

--- a/docker/docs.Dockerfile
+++ b/docker/docs.Dockerfile
@@ -1,5 +1,5 @@
 FROM python:latest
 COPY . .
-RUN make install
+RUN make install-lite
 EXPOSE 8080
 ENTRYPOINT ["streamlit", "run", "docs/Home.py", "--server.port=8080", "--server.address=0.0.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ requires-python = ">=3.6"
 dependencies = [
     "policyengine_core",
     "tables",
-    "survey_enhance",
-    "torch",
     "requests",
     "tqdm",
     "tabulate",
@@ -28,6 +26,8 @@ dev = [
     "black",
     "pytest",
     "policyengine_uk>=1.8.0",
+    "survey_enhance",
+    "torch",
     "streamlit",
 ]
 


### PR DESCRIPTION
This adds a lite install, so torch isn't added as an indirect dependency to PolicyEngine UK.