### PR TITLE
Increase epochs per year to 10k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2024-10-16 17:05:58
+
+### Added
+
+- Moved epoch count to 10k per year.
+
+## [1.4.0] - 2024-10-16 17:05:39
+
+### Added
+
+- Missing changelog entry.
+
+## [1.3.0] - 2024-10-16 17:02:56
+
+### Added
+
+- Re-run calibration with more epochs.
+
 ## [1.2.5] - 2024-09-18 13:57:40
 
 ### Fixed
@@ -48,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[1.5.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.4.0...1.5.0
+[1.4.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.3.0...1.4.0
+[1.3.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.2.5...1.3.0
 [1.2.5]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.2.4...1.2.5
 [1.2.4]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.2.3...1.2.4
 [1.2.3]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.2.2...1.2.3

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -39,3 +39,18 @@
     - GH actions naming.
     - Bug causing the Extended FRS to error.
   date: 2024-09-18 13:57:40
+- bump: minor
+  changes:
+    added:
+    - Re-run calibration with more epochs.
+  date: 2024-10-16 17:02:56
+- bump: minor
+  changes:
+    added:
+    - Missing changelog entry.
+  date: 2024-10-16 17:05:39
+- bump: minor
+  changes:
+    added:
+    - Moved epoch count to 10k per year.
+  date: 2024-10-16 17:05:58

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,0 @@
-- bump: minor
-  changes:
-    added:
-    - Add employer pension contributions.

--- a/policyengine_uk_data/datasets/frs/enhanced_frs.py
+++ b/policyengine_uk_data/datasets/frs/enhanced_frs.py
@@ -56,7 +56,7 @@ class EnhancedFRS_2022_23(EnhancedFRS):
     input_frs = ExtendedFRS_2022_23
     time_period = 2022
     end_year = 2028
-    url = "release://PolicyEngine/ukda/1.4.0/enhanced_frs_2022_23.h5"
+    url = "release://PolicyEngine/ukda/1.5.0/enhanced_frs_2022_23.h5"
 
 
 def reweight(

--- a/policyengine_uk_data/datasets/frs/enhanced_frs.py
+++ b/policyengine_uk_data/datasets/frs/enhanced_frs.py
@@ -104,7 +104,7 @@ def reweight(
 
     start_loss = None
 
-    iterator = trange(1_000)
+    iterator = trange(10_000)
     for i in iterator:
         optimizer.zero_grad()
         weights_ = dropout_weights(weights, dropout_rate)

--- a/policyengine_uk_data/datasets/frs/frs.py
+++ b/policyengine_uk_data/datasets/frs/frs.py
@@ -759,7 +759,7 @@ def add_expenses(
         sum_to_entity(job.DEDUC1.fillna(0), job.person_id, person.index) * 52,
     )
     frs["employer_pension_contributions"] = (
-        frs["employee_pension_contributions"] * 2.5
+        frs["employee_pension_contributions"] * 3
     )  # Rough estimate based on aggregates.
 
     frs["housing_service_charges"] = (

--- a/policyengine_uk_data/datasets/frs/frs.py
+++ b/policyengine_uk_data/datasets/frs/frs.py
@@ -115,7 +115,7 @@ class FRS_2022_23(FRS):
     label = "FRS (2022-23)"
     file_path = STORAGE_FOLDER / "frs_2022_23.h5"
     time_period = 2022
-    url = "release://PolicyEngine/ukda/1.4.0/frs_2022_23.h5"
+    url = "release://PolicyEngine/ukda/1.5.0/frs_2022_23.h5"
 
 
 def add_id_variables(frs: h5py.File, person: DataFrame, household: DataFrame):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "policyengine_uk_data"
-version = "1.4.0"
+version = "1.5.0"
 description = "A package to create representative microdata for the UK."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
I noticed that we were not quite hitting the total employment income target in 2026 onwards, causing the trend line to move down. I've increased the training epochs to 10,000 which seemed to fix this.