### PR TITLE
Add index.html to fix GitHub Pages 404 error

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>PolicyEngine UK Data</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem;
+      line-height: 1.6;
+      color: #333;
+    }
+    h1 {
+      color: #2c3e50;
+      border-bottom: 2px solid #3498db;
+      padding-bottom: 0.5rem;
+    }
+    .content {
+      margin-top: 2rem;
+    }
+    .links {
+      margin-top: 2rem;
+    }
+    .links a {
+      display: inline-block;
+      margin-right: 1rem;
+      margin-bottom: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #3498db;
+      color: white;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+    .links a:hover {
+      background-color: #2980b9;
+    }
+  </style>
+</head>
+<body>
+  <h1>PolicyEngine UK Data</h1>
+  
+  <div class="content">
+    <p>Welcome to the PolicyEngine UK Data documentation and methodology site.</p>
+    
+    <p>This site contains documentation for data sources, methodologies, and validation processes used in PolicyEngine UK.</p>
+    
+    <div class="links">
+      <a href="intro.html">Introduction</a>
+      <a href="methodology.html">Methodology</a>
+      <a href="validation/">Validation</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
GitHub Pages requires an index.html file at the root of the docs folder to serve content at the repository's GitHub Pages URL.

🤖 Generated with [Claude Code](https://claude.ai/code)