### PR TITLE
Fix Jupyter Book deployment to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,58 @@
+name: Deploy Jupyter Book
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: |
+          uv pip install -e ".[dev]" --system
+          uv pip install jupyter-book myst-nb --system
+
+      - name: Build book
+        run: myst build docs --html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Jupyter Book deployment to GitHub Pages by adding docs workflow and fixing branch reference

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ execute:
 
 repository:
   url: https://github.com/policyengine/policyengine-uk-data
-  branch: master
+  branch: main
   path_to_book: docs
 
 sphinx:


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to build and deploy Jupyter Book documentation
- Fixes branch reference in `_config.yml` from `master` to `main`
- Configures proper GitHub Pages deployment with required permissions

## Changes
- **`.github/workflows/docs.yaml`**: New workflow to build docs with `myst build` and deploy to GitHub Pages
- **`docs/_config.yml`**: Updated branch reference from `master` to `main`
- **`changelog_entry.yaml`**: Added changelog entry

## Test plan
- [ ] Workflow runs successfully on push to main
- [ ] Documentation builds without errors
- [ ] GitHub Pages site is accessible at https://policyengine.github.io/policyengine-uk-data/

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)