### PR TITLE
Re-add dividends to calibration set

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+      - Re-add dividends to calibration target set.

--- a/policyengine_uk_data/utils/loss.py
+++ b/policyengine_uk_data/utils/loss.py
@@ -255,6 +255,7 @@ def create_target_matrix(
         "private_pension_income",
         "property_income",
         "savings_interest_income",
+        "dividend_income",
     ]
 
     income_df = sim.calculate_dataframe(["total_income"] + INCOME_VARIABLES)


### PR DESCRIPTION
Re-adds dividend income to the calibration target set. Previously dropped, which meant weights didn't properly account for dividend income distribution.

Fixes #196