### PR TITLE
Generate random seeds in dataset for reproducible stochastic simulations

### DIFF
--- a/policyengine_uk_data/datasets/frs.py
+++ b/policyengine_uk_data/datasets/frs.py
@@ -751,40 +751,28 @@ def create_frs(
         paragraph_3 | paragraph_4 | paragraph_5
     )
 
-    # Add random variables which are for now in policyengine-uk.
+    # Add random seed variables for stochastic simulation
+    # These replace the old approach of calculating random variables directly
+    # Random seeds are generated once during dataset creation and stored
 
-    RANDOM_VARIABLES = [
-        "would_evade_tv_licence_fee",
-        "would_claim_pc",
-        "would_claim_uc",
-        "would_claim_child_benefit",
-        "main_residential_property_purchased_is_first_home",
-        "household_owns_tv",
-        "is_higher_earner",
-        "attends_private_school",
-    ]
+    generator = np.random.default_rng(seed=100)
 
-    for variable in RANDOM_VARIABLES:
-        value = sim.calculate(variable).values
-        entity = sim.tax_benefit_system.variables[variable].entity.key
-        if entity == "person":
-            pe_person[variable] = value
-        elif entity == "household":
-            pe_household[variable] = value
-        elif entity == "benunit":
-            pe_benunit[variable] = value
+    pe_person["person_random_seed"] = generator.random(len(pe_person))
+    pe_benunit["benunit_random_seed"] = generator.random(len(pe_benunit))
+    pe_household["household_random_seed"] = generator.random(len(pe_household))
 
     # Add Tax-Free Childcare assumptions
+    # Use seeded generator for reproducibility
 
     count_benunits = len(pe_benunit)
 
-    extended_would_claim = np.random.random(count_benunits) < 0.812
-    tfc_would_claim = np.random.random(count_benunits) < 0.586
-    universal_would_claim = np.random.random(count_benunits) < 0.563
-    targeted_would_claim = np.random.random(count_benunits) < 0.597
+    extended_would_claim = generator.random(count_benunits) < 0.812
+    tfc_would_claim = generator.random(count_benunits) < 0.586
+    universal_would_claim = generator.random(count_benunits) < 0.563
+    targeted_would_claim = generator.random(count_benunits) < 0.597
 
     # Generate extended childcare hours usage values with mean 15.019 and sd 4.972
-    extended_hours_values = np.random.normal(15.019, 4.972, count_benunits)
+    extended_hours_values = generator.normal(15.019, 4.972, count_benunits)
     # Clip values to be between 0 and 30 hours
     extended_hours_values = np.clip(extended_hours_values, 0, 30)
 

--- a/policyengine_uk_data/datasets/imputations/capital_gains.py
+++ b/policyengine_uk_data/datasets/imputations/capital_gains.py
@@ -125,6 +125,9 @@ def impute_cg_to_doubled_dataset(
 
     logging.info("Imputing capital gains among those with gains")
 
+    # Use seeded generator for reproducibility
+    generator = np.random.default_rng(seed=100)
+
     for i in range(len(capital_gains)):
         row = capital_gains.iloc[i]
         spline = UnivariateSpline(
@@ -136,7 +139,7 @@ def impute_cg_to_doubled_dataset(
         upper = row.maximum_total_income
         ti_in_range = (ti >= lower) * (ti < upper)
         in_target_range = has_cg * ti_in_range > 0
-        quantiles = np.random.random(int(in_target_range.sum()))
+        quantiles = generator.random(int(in_target_range.sum()))
         pred_capital_gains = spline(quantiles)
         new_cg[in_target_range] = pred_capital_gains
 

--- a/policyengine_uk_data/datasets/imputations/income.py
+++ b/policyengine_uk_data/datasets/imputations/income.py
@@ -51,7 +51,9 @@ def generate_spi_table(spi: pd.DataFrame):
     LOWER = np.array([0, 16, 25, 35, 45, 55, 65, 75])
     UPPER = np.array([16, 25, 35, 45, 55, 65, 75, 80])
     age_range = spi.AGERANGE
-    spi["age"] = LOWER[age_range] + np.random.rand(len(spi)) * (
+    # Use seeded generator for reproducibility
+    generator = np.random.default_rng(seed=100)
+    spi["age"] = LOWER[age_range] + generator.random(len(spi)) * (
         UPPER[age_range] - LOWER[age_range]
     )
 

--- a/policyengine_uk_data/datasets/spi.py
+++ b/policyengine_uk_data/datasets/spi.py
@@ -73,8 +73,10 @@ def create_spi(
     age_range = df.AGERANGE
 
     # Randomly assign ages in age ranges
+    # Use seeded generator for reproducibility
 
-    percent_along_age_range = np.random.rand(len(df))
+    generator = np.random.default_rng(seed=100)
+    percent_along_age_range = generator.random(len(df))
     min_age = np.array([AGE_RANGES[age][0] for age in age_range])
     max_age = np.array([AGE_RANGES[age][1] for age in age_range])
     person["age"] = (


### PR DESCRIPTION
## Summary

This PR moves random number generation from policyengine-uk into the dataset generation, following the pattern established in policyengine-us-data.

**⚠️ MERGE ORDER: This PR must be merged BEFORE the companion policyengine-uk PR**

## Changes

- Add random seed generation in FRS dataset for person, benunit, and household entities
- Update SPI dataset to use seeded generator for age assignment
- Update income imputation to use seeded generator for age assignment  
- Update capital gains imputation to use seeded generator for quantile sampling
- Update childcare assumptions to use seeded generator

All random generation now uses `np.random.default_rng(seed=100)` for full reproducibility across dataset builds.

This replaces the previous approach of calculating random variables directly during simulation and instead stores random seeds in the dataset that can be used by variables in policyengine-uk.

## Related PRs

- policyengine-uk: [Will be created next]

## Test Plan

- [ ] FRS dataset generation completes successfully
- [ ] Random seeds are generated for all three entity types
- [ ] Seeds are reproducible across builds with same seed value
- [ ] Companion policyengine-uk PR passes all tests after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>