### PR TITLE
Refactor income imputation and remove winter fuel allowance from loss calculations

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - Refactored income imputation to selectively impute only dividend income on the main dataset.
+    - Removed winter fuel allowance from loss calculations.

--- a/policyengine_uk_data/utils/loss.py
+++ b/policyengine_uk_data/utils/loss.py
@@ -122,7 +122,7 @@ def create_target_matrix(
         on_uc * ~unemployed
     )
 
-    df["obr/winter_fuel_allowance_count"] = pe_count("winter_fuel_allowance")
+    # df["obr/winter_fuel_allowance_count"] = pe_count("winter_fuel_allowance")
     df["obr/capital_gains_tax"] = pe("capital_gains_tax")
     df["obr/child_benefit"] = pe("child_benefit")
 
@@ -152,7 +152,7 @@ def create_target_matrix(
     )
 
     df["obr/vat"] = pe("vat")
-    df["obr/winter_fuel_allowance"] = pe("winter_fuel_allowance")
+    # df["obr/winter_fuel_allowance"] = pe("winter_fuel_allowance")
 
     # Not strictly from the OBR but from the 2024 Independent Schools Council census. OBR will be using that.
     df["obr/private_school_students"] = pe("attends_private_school")


### PR DESCRIPTION
Fixes #210

This refactors the income imputation logic to be more selective about what gets imputed on the main dataset.

Changes:
- Extracted imputation logic into a reusable `impute_over_incomes` function
- Now only imputes dividend income on the main dataset (while still imputing all income components on the zero-weight copy)
- Removed winter fuel allowance from loss calculations (both count and total metrics)

This should improve accuracy by being more targeted about which income components need imputation on the full dataset.