### PR TITLE
Zero out fuel spending for non-fuel households

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Zero out fuel spending for households without fuel consumption

--- a/docs/imputations.md
+++ b/docs/imputations.md
@@ -106,6 +106,8 @@ LCFS 2-week diaries undercount fuel purchasers (58%) compared to actual vehicle 
 
 4. **At FRS imputation time**: Compute `has_fuel_consumption` directly from `num_vehicles` (already calibrated to NTS targets)
 
+5. **Zero non-fuel households**: After imputation, set `petrol_spending` and `diesel_spending` to zero for households where `has_fuel_consumption = 0`
+
 This ensures fuel duty incidence aligns with actual vehicle ownership (~70% of households = 78% vehicles × 90% ICE) rather than LCFS diary randomness.
 
 ---

--- a/policyengine_uk_data/datasets/imputations/consumption.py
+++ b/policyengine_uk_data/datasets/imputations/consumption.py
@@ -344,6 +344,12 @@ def impute_consumption(dataset: UKSingleYearDataset) -> UKSingleYearDataset:
     for column in output_df.columns:
         dataset.household[column] = output_df[column].values
 
+    # Zero out fuel spending for households without fuel consumption
+    # This ensures only ICE vehicle owners contribute to fuel duty
+    no_fuel = has_fuel_consumption == 0
+    dataset.household["petrol_spending"][no_fuel] = 0
+    dataset.household["diesel_spending"][no_fuel] = 0
+
     dataset.validate()
 
     return dataset


### PR DESCRIPTION
## Summary
- Households with `has_fuel_consumption=0` (non-vehicle owners or EV owners) now have `petrol_spending` and `diesel_spending` set to zero after imputation
- This prevents the QRF from assigning fuel spending based on other predictors to households that shouldn't have any fuel consumption
- Should reduce the fuel duty over-estimation seen in calibration (was £49.5B vs £24.4B target)

## Context
After PR #244 added `has_fuel_consumption` as a predictor, fuel duties were over-estimated by ~100%. This happened because:
1. The QRF could still assign fuel spending to non-fuel households based on other predictors
2. The calibration couldn't reduce this because it conflicts with other targets

## Test plan
- [ ] CI passes
- [ ] Fuel duty estimate should be closer to £24.4B OBR target

🤖 Generated with [Claude Code](https://claude.com/claude-code)