### PR TITLE
Fix black formatting for 5 files

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fix black formatting for 5 files to comply with black 26.1.0

--- a/policyengine_uk_data/datasets/imputations/salary_sacrifice.py
+++ b/policyengine_uk_data/datasets/imputations/salary_sacrifice.py
@@ -23,7 +23,6 @@ from policyengine_uk_data.storage import STORAGE_FOLDER
 from policyengine_uk.data import UKSingleYearDataset
 from policyengine_uk import Microsimulation
 
-
 PREDICTORS = [
     "age",
     "employment_income",

--- a/policyengine_uk_data/datasets/imputations/wealth.py
+++ b/policyengine_uk_data/datasets/imputations/wealth.py
@@ -11,7 +11,6 @@ from policyengine_uk_data.storage import STORAGE_FOLDER
 from policyengine_uk.data import UKSingleYearDataset
 from policyengine_uk import Microsimulation
 
-
 WAS_TAB_FOLDER = STORAGE_FOLDER / "was_2006_20"
 
 REGIONS = {

--- a/policyengine_uk_data/storage/download_completed_datasets.py
+++ b/policyengine_uk_data/storage/download_completed_datasets.py
@@ -1,7 +1,6 @@
 from policyengine_uk_data.utils.huggingface import download, upload
 from pathlib import Path
 
-
 FOLDER = Path(__file__).parent
 
 FILES = [

--- a/policyengine_uk_data/tests/microsimulation/test_reform_impacts.py
+++ b/policyengine_uk_data/tests/microsimulation/test_reform_impacts.py
@@ -10,7 +10,6 @@ from policyengine_uk import Microsimulation
 from policyengine_core.data import Dataset
 from policyengine_uk_data.storage import STORAGE_FOLDER
 
-
 # Load configuration from YAML file
 config_path = Path(__file__).parent / "reforms_config.yaml"
 with open(config_path, "r") as f:

--- a/policyengine_uk_data/tests/test_property_purchased.py
+++ b/policyengine_uk_data/tests/test_property_purchased.py
@@ -19,7 +19,6 @@ Verification against official SDLT revenue (2024-25):
 
 import pytest
 
-
 PROPERTY_PURCHASE_RATE = 0.0385
 
 


### PR DESCRIPTION
## Summary
- Remove extra blank lines after imports to comply with black 26.1.0
- Fixes CI lint failures

## Files changed
- `salary_sacrifice.py`
- `wealth.py`
- `download_completed_datasets.py`
- `test_reform_impacts.py`
- `test_property_purchased.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)