### PR TITLE
Add Modal GPU calibration

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -53,6 +53,9 @@ jobs:
         run: make data
         env:
           TESTING: "1"
+          MODAL_CALIBRATE: "1"
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       - name: Save calibration log (constituencies)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -58,6 +58,10 @@ jobs:
           HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
       - name: Build datasets
         run: make data
+        env:
+          MODAL_CALIBRATE: "1"
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       - name: Save calibration log (constituencies)
         uses: actions/upload-artifact@v4
         with:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Modal GPU calibration support to speed up CI runs

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -27,9 +27,7 @@ def _build_weights_init(dataset, area_count, r):
     areas_per_household = np.maximum(r.sum(axis=0), 1)
     original_weights = np.log(
         dataset.household.household_weight.values / areas_per_household
-        + np.random.random(
-            len(dataset.household.household_weight.values)
-        )
+        + np.random.random(len(dataset.household.household_weight.values))
         * 0.01
     )
     return np.ones((area_count, len(original_weights))) * original_weights
@@ -51,15 +49,18 @@ def _run_modal_calibrations(
         run_calibration,
     )
 
+    frs_c = frs.copy()
+    frs_la = frs.copy()
+
     # Build arrays for constituencies
-    matrix_c, y_c, r_c = create_constituency_target_matrix(frs)
-    m_nat_c, y_nat_c = create_national_target_matrix(frs)
-    wi_c = _build_weights_init(frs, 650, r_c)
+    matrix_c, y_c, r_c = create_constituency_target_matrix(frs_c)
+    m_nat_c, y_nat_c = create_national_target_matrix(frs_c)
+    wi_c = _build_weights_init(frs_c, 650, r_c)
 
     # Build arrays for local authorities
-    matrix_la, y_la, r_la = create_local_authority_target_matrix(frs)
-    m_nat_la, y_nat_la = create_national_target_matrix(frs)
-    wi_la = _build_weights_init(frs, 360, r_la)
+    matrix_la, y_la, r_la = create_local_authority_target_matrix(frs_la)
+    m_nat_la, y_nat_la = create_national_target_matrix(frs_la)
+    wi_la = _build_weights_init(frs_la, 360, r_la)
 
     def _arr(x):
         return x.values if hasattr(x, "values") else x
@@ -220,9 +221,7 @@ def main():
                     weights_c.sum(axis=0)
                 )
 
-                update_dataset(
-                    "Calibrate constituency weights", "completed"
-                )
+                update_dataset("Calibrate constituency weights", "completed")
                 update_dataset(
                     "Calibrate local authority weights", "completed"
                 )
@@ -246,9 +245,7 @@ def main():
                     get_performance=get_performance,
                     nested_progress=nested_progress,
                 )
-                update_dataset(
-                    "Calibrate constituency weights", "completed"
-                )
+                update_dataset("Calibrate constituency weights", "completed")
 
                 update_dataset(
                     "Calibrate local authority weights", "processing"
@@ -272,7 +269,9 @@ def main():
                 )
 
             update_dataset("Downrate to 2023", "processing")
-            frs_calibrated = uprate_dataset(frs_calibrated_constituencies, 2023)
+            frs_calibrated = uprate_dataset(
+                frs_calibrated_constituencies, 2023
+            )
             update_dataset("Downrate to 2023", "completed")
 
             update_dataset("Save final dataset", "processing")

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -197,101 +197,52 @@ def main():
             frs.save(STORAGE_FOLDER / "frs_2023_24.h5")
             update_dataset("Create base FRS dataset", "completed")
 
-            if USE_MODAL:
-                import modal
-                from policyengine_uk_data.utils.modal_calibrate import (
-                    app,
-                    run_imputation,
-                )
-                from policyengine_uk.data import UKSingleYearDataset
-                import tempfile
+            from policyengine_uk_data.datasets.imputations import (
+                impute_consumption,
+                impute_wealth,
+                impute_vat,
+                impute_income,
+                impute_capital_gains,
+                impute_services,
+                impute_salary_sacrifice,
+                impute_student_loan_plan,
+            )
 
-                for step in [
-                    "Impute consumption",
-                    "Impute wealth",
-                    "Impute VAT",
-                    "Impute public service usage",
-                    "Impute income",
-                    "Impute capital gains",
-                    "Impute salary sacrifice",
-                    "Impute student loan plan",
-                    "Uprate to 2025",
-                ]:
-                    update_dataset(step, "processing")
+            update_dataset("Impute wealth", "processing")
+            frs = impute_wealth(frs)
+            update_dataset("Impute wealth", "completed")
 
-                with modal.enable_output(), app.run():
-                    frs_bytes = open(
-                        STORAGE_FOLDER / "frs_2023_24.h5", "rb"
-                    ).read()
-                    frs_bytes_out = run_imputation.remote(frs_bytes, year=2023)
+            update_dataset("Impute consumption", "processing")
+            frs = impute_consumption(frs)
+            update_dataset("Impute consumption", "completed")
 
-                with tempfile.NamedTemporaryFile(
-                    suffix=".h5", delete=False
-                ) as f:
-                    f.write(frs_bytes_out)
-                    frs_path = f.name
-                frs = UKSingleYearDataset(file_path=frs_path)
+            update_dataset("Impute VAT", "processing")
+            frs = impute_vat(frs)
+            update_dataset("Impute VAT", "completed")
 
-                for step in [
-                    "Impute consumption",
-                    "Impute wealth",
-                    "Impute VAT",
-                    "Impute public service usage",
-                    "Impute income",
-                    "Impute capital gains",
-                    "Impute salary sacrifice",
-                    "Impute student loan plan",
-                    "Uprate to 2025",
-                ]:
-                    update_dataset(step, "completed")
-            else:
-                from policyengine_uk_data.datasets.imputations import (
-                    impute_consumption,
-                    impute_wealth,
-                    impute_vat,
-                    impute_income,
-                    impute_capital_gains,
-                    impute_services,
-                    impute_salary_sacrifice,
-                    impute_student_loan_plan,
-                )
+            update_dataset("Impute public service usage", "processing")
+            frs = impute_services(frs)
+            update_dataset("Impute public service usage", "completed")
 
-                update_dataset("Impute wealth", "processing")
-                frs = impute_wealth(frs)
-                update_dataset("Impute wealth", "completed")
+            update_dataset("Impute income", "processing")
+            frs = impute_income(frs)
+            update_dataset("Impute income", "completed")
 
-                update_dataset("Impute consumption", "processing")
-                frs = impute_consumption(frs)
-                update_dataset("Impute consumption", "completed")
+            update_dataset("Impute capital gains", "processing")
+            frs = impute_capital_gains(frs)
+            update_dataset("Impute capital gains", "completed")
 
-                update_dataset("Impute VAT", "processing")
-                frs = impute_vat(frs)
-                update_dataset("Impute VAT", "completed")
+            update_dataset("Impute salary sacrifice", "processing")
+            frs = impute_salary_sacrifice(frs)
+            update_dataset("Impute salary sacrifice", "completed")
 
-                update_dataset("Impute public service usage", "processing")
-                frs = impute_services(frs)
-                update_dataset("Impute public service usage", "completed")
+            update_dataset("Impute student loan plan", "processing")
+            frs = impute_student_loan_plan(frs, year=2025)
+            update_dataset("Impute student loan plan", "completed")
 
-                update_dataset("Impute income", "processing")
-                frs = impute_income(frs)
-                update_dataset("Impute income", "completed")
-
-                update_dataset("Impute capital gains", "processing")
-                frs = impute_capital_gains(frs)
-                update_dataset("Impute capital gains", "completed")
-
-                update_dataset("Impute salary sacrifice", "processing")
-                frs = impute_salary_sacrifice(frs)
-                update_dataset("Impute salary sacrifice", "completed")
-
-                update_dataset("Impute student loan plan", "processing")
-                frs = impute_student_loan_plan(frs, year=2025)
-                update_dataset("Impute student loan plan", "completed")
-
-            if not USE_MODAL:
-                update_dataset("Uprate to 2025", "processing")
-                frs = uprate_dataset(frs, 2025)
-                update_dataset("Uprate to 2025", "completed")
+            update_dataset("Uprate to 2025", "processing")
+            frs = uprate_dataset(frs, 2025)
+            update_dataset("Uprate to 2025", "completed")
 
             from policyengine_uk_data.datasets.local_areas.constituencies.loss import (
                 create_constituency_target_matrix,

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -54,7 +54,7 @@ def _run_modal_calibrations(
         return x.values if hasattr(x, "values") else x
 
     # Build national matrix once and reuse for both calibrations
-    m_nat, y_nat = create_national_target_matrix(frs)
+    m_nat, y_nat = create_national_target_matrix(frs.copy())
     b_m_nat = _dump(_arr(m_nat))
     b_y_nat = _dump(_arr(y_nat))
     del m_nat, y_nat

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -52,41 +52,39 @@ def _run_modal_calibrations(
     def _arr(x):
         return x.values if hasattr(x, "values") else x
 
-    # Build and serialise constituency arrays, then free before building LA
-    frs_copy = frs.copy()
-    matrix_c, y_c, r_c = create_constituency_target_matrix(frs_copy)
-    m_nat_c, y_nat_c = create_national_target_matrix(frs_copy)
-    wi_c = _build_weights_init(frs_copy, 650, r_c)
-    args_c = (
-        _dump(_arr(matrix_c)),
-        _dump(_arr(y_c)),
-        _dump(r_c),
-        _dump(_arr(m_nat_c)),
-        _dump(_arr(y_nat_c)),
-        _dump(wi_c),
-        epochs,
-    )
-    del matrix_c, y_c, r_c, m_nat_c, y_nat_c, wi_c, frs_copy
-
-    frs_copy = frs.copy()
-    matrix_la, y_la, r_la = create_local_authority_target_matrix(frs_copy)
-    m_nat_la, y_nat_la = create_national_target_matrix(frs_copy)
-    wi_la = _build_weights_init(frs_copy, 360, r_la)
-    args_la = (
-        _dump(_arr(matrix_la)),
-        _dump(_arr(y_la)),
-        _dump(r_la),
-        _dump(_arr(m_nat_la)),
-        _dump(_arr(y_nat_la)),
-        _dump(wi_la),
-        epochs,
-    )
-    del matrix_la, y_la, r_la, m_nat_la, y_nat_la, wi_la, frs_copy
-
-    # Submit both jobs before waiting on either; Modal runs them in parallel
     with app.run():
-        fut_c = run_calibration.spawn(*args_c)
-        fut_la = run_calibration.spawn(*args_la)
+        # Build constituency arrays, spawn immediately, then free before LA
+        frs_copy = frs.copy()
+        matrix_c, y_c, r_c = create_constituency_target_matrix(frs_copy)
+        m_nat_c, y_nat_c = create_national_target_matrix(frs_copy)
+        wi_c = _build_weights_init(frs_copy, 650, r_c)
+        fut_c = run_calibration.spawn(
+            _dump(_arr(matrix_c)),
+            _dump(_arr(y_c)),
+            _dump(r_c),
+            _dump(_arr(m_nat_c)),
+            _dump(_arr(y_nat_c)),
+            _dump(wi_c),
+            epochs,
+        )
+        del matrix_c, y_c, r_c, m_nat_c, y_nat_c, wi_c, frs_copy
+
+        # Build LA arrays, spawn, then free
+        frs_copy = frs.copy()
+        matrix_la, y_la, r_la = create_local_authority_target_matrix(frs_copy)
+        m_nat_la, y_nat_la = create_national_target_matrix(frs_copy)
+        wi_la = _build_weights_init(frs_copy, 360, r_la)
+        fut_la = run_calibration.spawn(
+            _dump(_arr(matrix_la)),
+            _dump(_arr(y_la)),
+            _dump(r_la),
+            _dump(_arr(m_nat_la)),
+            _dump(_arr(y_nat_la)),
+            _dump(wi_la),
+            epochs,
+        )
+        del matrix_la, y_la, r_la, m_nat_la, y_nat_la, wi_la, frs_copy
+
         weights_c = np.load(io.BytesIO(fut_c.get()))
         weights_la = np.load(io.BytesIO(fut_la.get()))
 

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -197,12 +197,15 @@ def main():
             update_dataset("Create base FRS dataset", "completed")
 
             if USE_MODAL:
+                import modal
                 from policyengine_uk_data.utils.modal_calibrate import (
                     app,
                     run_imputation,
                 )
                 from policyengine_uk.data import UKSingleYearDataset
                 import tempfile
+
+                modal.enable_output()
 
                 for step in [
                     "Impute consumption",

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -66,6 +66,7 @@ def _run_modal_calibrations(
     Returns (constituency_weights, la_weights) as numpy arrays and
     writes constituency_calibration_log.csv / la_calibration_log.csv.
     """
+    import modal
     import pandas as pd
     from policyengine_uk_data.utils.modal_calibrate import (
         app,
@@ -116,7 +117,7 @@ def _run_modal_calibrations(
     del matrix_la, y_la, wi_la, r_la, frs_copy
     gc.collect()
 
-    with app.run():
+    with modal.enable_output(), app.run():
         fut_c = run_calibration.spawn(
             b_matrix_c, b_y_c, b_r_c, b_m_nat, b_y_nat, b_wi_c, epochs
         )
@@ -205,8 +206,6 @@ def main():
                 from policyengine_uk.data import UKSingleYearDataset
                 import tempfile
 
-                modal.enable_output()
-
                 for step in [
                     "Impute consumption",
                     "Impute wealth",
@@ -220,7 +219,7 @@ def main():
                 ]:
                     update_dataset(step, "processing")
 
-                with app.run():
+                with modal.enable_output(), app.run():
                     frs_bytes = open(
                         STORAGE_FOLDER / "frs_2023_24.h5", "rb"
                     ).read()

--- a/policyengine_uk_data/utils/calibrate.py
+++ b/policyengine_uk_data/utils/calibrate.py
@@ -8,6 +8,202 @@ from policyengine_uk.data import UKSingleYearDataset
 from policyengine_uk_data.utils.progress import ProcessingProgress
 
 
+def _run_optimisation(
+    matrix_np: np.ndarray,
+    y_np: np.ndarray,
+    r_np: np.ndarray,
+    matrix_national_np: np.ndarray,
+    y_national_np: np.ndarray,
+    weights_init_np: np.ndarray,
+    epochs: int,
+    device: torch.device,
+    excluded_training_targets_local: np.ndarray | None = None,
+    excluded_training_targets_national: np.ndarray | None = None,
+    verbose: bool = False,
+    area_name: str = "area",
+    progress_tracker=None,
+    nested_progress=None,
+    log_csv: str | None = None,
+    get_performance=None,
+    m_c_orig=None,
+    y_c_orig=None,
+    m_n_orig=None,
+    y_n_orig=None,
+    weight_file: str | None = None,
+    dataset_key: str = "2025",
+    dataset=None,
+) -> np.ndarray:
+    """
+    Pure optimisation loop (Adam, PyTorch). Device-agnostic — pass
+    ``device=torch.device("cuda")`` for GPU or ``"cpu"`` for CPU.
+
+    Returns the final weights array (area_count × n_households).
+    """
+    metrics = torch.tensor(matrix_np, dtype=torch.float32, device=device)
+    y = torch.tensor(y_np, dtype=torch.float32, device=device)
+    matrix_national = torch.tensor(
+        matrix_national_np, dtype=torch.float32, device=device
+    )
+    y_national = torch.tensor(
+        y_national_np, dtype=torch.float32, device=device
+    )
+    r = torch.tensor(r_np, dtype=torch.float32, device=device)
+
+    weights = torch.tensor(
+        weights_init_np,
+        dtype=torch.float32,
+        device=device,
+        requires_grad=True,
+    )
+
+    dropout_targets = (
+        excluded_training_targets_local is not None
+        and excluded_training_targets_local.any()
+    )
+
+    def sre(x, y_t):
+        one_way = ((1 + x) / (1 + y_t) - 1) ** 2
+        other_way = ((1 + y_t) / (1 + x) - 1) ** 2
+        return torch.min(one_way, other_way)
+
+    def loss_fn(w, validation: bool = False):
+        pred_local = (w.unsqueeze(-1) * metrics.unsqueeze(0)).sum(dim=1)
+        if dropout_targets and excluded_training_targets_local is not None:
+            mask = (
+                excluded_training_targets_local
+                if validation
+                else ~excluded_training_targets_local
+            )
+            pred_local = pred_local[:, mask]
+            mse_local = torch.mean(sre(pred_local, y[:, mask]))
+        else:
+            mse_local = torch.mean(sre(pred_local, y))
+
+        pred_national = (w.sum(axis=0) * matrix_national.T).sum(axis=1)
+        if (
+            dropout_targets
+            and excluded_training_targets_national is not None
+        ):
+            mask = (
+                excluded_training_targets_national
+                if validation
+                else ~excluded_training_targets_national
+            )
+            pred_national = pred_national[mask]
+            mse_national = torch.mean(
+                sre(pred_national, y_national[mask])
+            )
+        else:
+            mse_national = torch.mean(sre(pred_national, y_national))
+
+        return mse_local + mse_national
+
+    def pct_close(w, t=0.1, local=True, national=True):
+        numerator = 0
+        denominator = 0
+        if local:
+            pred_local = (w.unsqueeze(-1) * metrics.unsqueeze(0)).sum(
+                dim=1
+            )
+            numerator += torch.sum(
+                torch.abs((pred_local / (1 + y) - 1)) < t
+            ).item()
+            denominator += pred_local.shape[0] * pred_local.shape[1]
+        if national:
+            pred_national = (w.sum(axis=0) * matrix_national.T).sum(axis=1)
+            numerator += torch.sum(
+                torch.abs((pred_national / (1 + y_national) - 1)) < t
+            ).item()
+            denominator += pred_national.shape[0]
+        return numerator / denominator
+
+    def dropout_weights(w, p):
+        if p == 0:
+            return w
+        mask = torch.rand_like(w) < p
+        mean = w[~mask].mean()
+        w2 = w.clone()
+        w2[mask] = mean
+        return w2
+
+    optimizer = torch.optim.Adam([weights], lr=1e-1)
+    final_weights = (torch.exp(weights) * r).detach().cpu().numpy()
+    performance = pd.DataFrame()
+
+    def _epoch_step(epoch):
+        nonlocal final_weights, performance
+        optimizer.zero_grad()
+        weights_ = torch.exp(dropout_weights(weights, 0.05)) * r
+        l = loss_fn(weights_)
+        l.backward()
+        optimizer.step()
+
+        local_close = pct_close(weights_, local=True, national=False)
+        national_close = pct_close(weights_, local=False, national=True)
+
+        if epoch % 10 == 0:
+            final_weights = (torch.exp(weights) * r).detach().cpu().numpy()
+
+            if log_csv and get_performance and m_c_orig is not None:
+                perf = get_performance(
+                    final_weights,
+                    m_c_orig,
+                    y_c_orig,
+                    m_n_orig,
+                    y_n_orig,
+                    [],
+                )
+                perf["epoch"] = epoch
+                perf["loss"] = perf.rel_abs_error**2
+                perf["target_name"] = [
+                    f"{a}/{m}"
+                    for a, m in zip(perf.name, perf.metric)
+                ]
+                performance = pd.concat(
+                    [performance, perf], ignore_index=True
+                )
+                performance.to_csv(log_csv, index=False)
+
+            if weight_file:
+                with h5py.File(STORAGE_FOLDER / weight_file, "w") as f:
+                    f.create_dataset(dataset_key, data=final_weights)
+            if dataset is not None:
+                dataset.household.household_weight = final_weights.sum(
+                    axis=0
+                )
+
+        return l, local_close, national_close
+
+    if verbose and progress_tracker is not None:
+        with progress_tracker.track_calibration(
+            epochs, nested_progress
+        ) as update_calibration:
+            for epoch in range(epochs):
+                update_calibration(epoch + 1, calculating_loss=True)
+                l, _, _ = _epoch_step(epoch)
+                if dropout_targets:
+                    weights_ = torch.exp(
+                        dropout_weights(weights, 0.05)
+                    ) * r
+                    val_loss = loss_fn(weights_, validation=True)
+                    update_calibration(
+                        epoch + 1,
+                        loss_value=val_loss.item(),
+                        calculating_loss=False,
+                    )
+                else:
+                    update_calibration(
+                        epoch + 1,
+                        loss_value=l.item(),
+                        calculating_loss=False,
+                    )
+    else:
+        for epoch in range(epochs):
+            _epoch_step(epoch)
+
+    return final_weights
+
+
 def calibrate_local_areas(
     dataset: UKSingleYearDataset,
     matrix_fn,
@@ -22,22 +218,9 @@ def calibrate_local_areas(
     area_name: str = "area",
     get_performance=None,
     nested_progress=None,
-):
+) -> UKSingleYearDataset:
     """
-    Generic calibration function for local areas (constituencies, local authorities, etc.)
-
-    Args:
-        dataset: The dataset to calibrate
-        matrix_fn: Function that returns (matrix, targets, mask) for the local areas
-        national_matrix_fn: Function that returns (matrix, targets) for national totals
-        area_count: Number of areas (e.g., 650 for constituencies, 360 for local authorities)
-        weight_file: Name of the h5 file to save weights to
-        dataset_key: Key to use in the h5 file
-        epochs: Number of training epochs
-        excluded_training_targets: List of targets to exclude from training (for validation)
-        log_csv: CSV file to log performance to
-        verbose: Whether to print progress
-        area_name: Name of the area type for logging
+    Calibrate local-area weights on CPU using the extracted optimisation loop.
     """
     dataset = dataset.copy()
     matrix, y, r = matrix_fn(dataset)
@@ -45,29 +228,15 @@ def calibrate_local_areas(
     m_national, y_national = national_matrix_fn(dataset)
     m_n, y_n = m_national.copy(), y_national.copy()
 
-    # Weights - area_count x num_households
-    # Use country-aware initialization: divide each household's weight by the
-    # number of areas in its country, not the total area count. This ensures
-    # households start at approximately correct weight for their country's targets.
-    # The country_mask r[i,j]=1 iff household j is in same country as area i.
-    areas_per_household = r.sum(
-        axis=0
-    )  # number of areas each household can contribute to
-    areas_per_household = np.maximum(
-        areas_per_household, 1
-    )  # avoid division by zero
+    areas_per_household = r.sum(axis=0)
+    areas_per_household = np.maximum(areas_per_household, 1)
     original_weights = np.log(
         dataset.household.household_weight.values / areas_per_household
         + np.random.random(len(dataset.household.household_weight.values))
         * 0.01
     )
-    weights = torch.tensor(
-        np.ones((area_count, len(original_weights))) * original_weights,
-        dtype=torch.float32,
-        requires_grad=True,
-    )
+    weights_init = np.ones((area_count, len(original_weights))) * original_weights
 
-    # Set up validation targets if specified
     validation_targets_local = (
         matrix.columns.isin(excluded_training_targets)
         if hasattr(matrix, "columns")
@@ -78,215 +247,38 @@ def calibrate_local_areas(
         if hasattr(m_national, "columns")
         else None
     )
-    dropout_targets = len(excluded_training_targets) > 0
-
-    # Convert to tensors
-    metrics = torch.tensor(
-        matrix.values if hasattr(matrix, "values") else matrix,
-        dtype=torch.float32,
-    )
-    y = torch.tensor(
-        y.values if hasattr(y, "values") else y, dtype=torch.float32
-    )
-    matrix_national = torch.tensor(
-        m_national.values if hasattr(m_national, "values") else m_national,
-        dtype=torch.float32,
-    )
-    y_national = torch.tensor(
-        y_national.values if hasattr(y_national, "values") else y_national,
-        dtype=torch.float32,
-    )
-    r = torch.tensor(r, dtype=torch.float32)
-
-    def sre(x, y):
-        one_way = ((1 + x) / (1 + y) - 1) ** 2
-        other_way = ((1 + y) / (1 + x) - 1) ** 2
-        return torch.min(one_way, other_way)
-
-    def loss(w, validation: bool = False):
-        pred_local = (w.unsqueeze(-1) * metrics.unsqueeze(0)).sum(dim=1)
-        if dropout_targets and validation_targets_local is not None:
-            if validation:
-                mask = validation_targets_local
-            else:
-                mask = ~validation_targets_local
-            pred_local = pred_local[:, mask]
-            mse_local = torch.mean(sre(pred_local, y[:, mask]))
-        else:
-            mse_local = torch.mean(sre(pred_local, y))
-
-        pred_national = (w.sum(axis=0) * matrix_national.T).sum(axis=1)
-        if dropout_targets and validation_targets_national is not None:
-            if validation:
-                mask = validation_targets_national
-            else:
-                mask = ~validation_targets_national
-            pred_national = pred_national[mask]
-            mse_national = torch.mean(sre(pred_national, y_national[mask]))
-        else:
-            mse_national = torch.mean(sre(pred_national, y_national))
-
-        return mse_local + mse_national
-
-    def pct_close(w, t=0.1, local=True, national=True):
-        """Return the percentage of metrics that are within t% of the target"""
-        numerator = 0
-        denominator = 0
-
-        if local:
-            pred_local = (w.unsqueeze(-1) * metrics.unsqueeze(0)).sum(dim=1)
-            e_local = torch.sum(
-                torch.abs((pred_local / (1 + y) - 1)) < t
-            ).item()
-            c_local = pred_local.shape[0] * pred_local.shape[1]
-            numerator += e_local
-            denominator += c_local
-
-        if national:
-            pred_national = (w.sum(axis=0) * matrix_national.T).sum(axis=1)
-            e_national = torch.sum(
-                torch.abs((pred_national / (1 + y_national) - 1)) < t
-            ).item()
-            c_national = pred_national.shape[0]
-            numerator += e_national
-            denominator += c_national
-
-        return numerator / denominator
-
-    def dropout_weights(weights, p):
-        if p == 0:
-            return weights
-        # Replace p% of the weights with the mean value of the rest of them
-        mask = torch.rand_like(weights) < p
-        mean = weights[~mask].mean()
-        masked_weights = weights.clone()
-        masked_weights[mask] = mean
-        return masked_weights
-
-    optimizer = torch.optim.Adam([weights], lr=1e-1)
-    final_weights = (torch.exp(weights) * r).detach().numpy()
-    performance = pd.DataFrame()
 
     progress_tracker = ProcessingProgress() if verbose else None
 
-    if verbose and progress_tracker:
-        with progress_tracker.track_calibration(
-            epochs, nested_progress
-        ) as update_calibration:
-            for epoch in range(epochs):
-                update_calibration(epoch + 1, calculating_loss=True)
+    final_weights = _run_optimisation(
+        matrix_np=matrix.values if hasattr(matrix, "values") else matrix,
+        y_np=y.values if hasattr(y, "values") else y,
+        r_np=r,
+        matrix_national_np=m_national.values
+        if hasattr(m_national, "values")
+        else m_national,
+        y_national_np=y_national.values
+        if hasattr(y_national, "values")
+        else y_national,
+        weights_init_np=weights_init,
+        epochs=epochs,
+        device=torch.device("cpu"),
+        excluded_training_targets_local=validation_targets_local,
+        excluded_training_targets_national=validation_targets_national,
+        verbose=verbose,
+        area_name=area_name,
+        progress_tracker=progress_tracker,
+        nested_progress=nested_progress,
+        log_csv=log_csv,
+        get_performance=get_performance,
+        m_c_orig=m_c,
+        y_c_orig=y_c,
+        m_n_orig=m_n,
+        y_n_orig=y_n,
+        weight_file=weight_file,
+        dataset_key=dataset_key,
+        dataset=dataset,
+    )
 
-                optimizer.zero_grad()
-                weights_ = torch.exp(dropout_weights(weights, 0.05)) * r
-                l = loss(weights_)
-                l.backward()
-                optimizer.step()
-
-                local_close = pct_close(weights_, local=True, national=False)
-                national_close = pct_close(
-                    weights_, local=False, national=True
-                )
-
-                if dropout_targets:
-                    validation_loss = loss(weights_, validation=True)
-                    update_calibration(
-                        epoch + 1,
-                        loss_value=validation_loss.item(),
-                        calculating_loss=False,
-                    )
-                else:
-                    update_calibration(
-                        epoch + 1, loss_value=l.item(), calculating_loss=False
-                    )
-
-                if epoch % 10 == 0:
-                    final_weights = (torch.exp(weights) * r).detach().numpy()
-
-                    # Log performance if requested and get_performance function is available
-                    if log_csv and get_performance:
-                        performance_step = get_performance(
-                            final_weights,
-                            m_c,
-                            y_c,
-                            m_n,
-                            y_n,
-                            excluded_training_targets,
-                        )
-                        performance_step["epoch"] = epoch
-                        performance_step["loss"] = (
-                            performance_step.rel_abs_error**2
-                        )
-                        performance_step["target_name"] = [
-                            f"{area}/{metric}"
-                            for area, metric in zip(
-                                performance_step.name, performance_step.metric
-                            )
-                        ]
-                        performance = pd.concat(
-                            [performance, performance_step], ignore_index=True
-                        )
-                        performance.to_csv(log_csv, index=False)
-
-                    # Save weights
-                    with h5py.File(STORAGE_FOLDER / weight_file, "w") as f:
-                        f.create_dataset(dataset_key, data=final_weights)
-
-                    dataset.household.household_weight = final_weights.sum(
-                        axis=0
-                    )
-    else:
-        for epoch in range(epochs):
-            optimizer.zero_grad()
-            weights_ = torch.exp(dropout_weights(weights, 0.05)) * r
-            l = loss(weights_)
-            l.backward()
-            optimizer.step()
-
-            local_close = pct_close(weights_, local=True, national=False)
-            national_close = pct_close(weights_, local=False, national=True)
-
-            if verbose and (epoch % 1 == 0):
-                if dropout_targets:
-                    validation_loss = loss(weights_, validation=True)
-                    print(
-                        f"Training loss: {l.item():,.3f}, Validation loss: {validation_loss.item():,.3f}, Epoch: {epoch}, "
-                        f"{area_name}<10%: {local_close:.1%}, National<10%: {national_close:.1%}"
-                    )
-                else:
-                    print(
-                        f"Loss: {l.item()}, Epoch: {epoch}, {area_name}<10%: {local_close:.1%}, National<10%: {national_close:.1%}"
-                    )
-
-        if epoch % 10 == 0:
-            final_weights = (torch.exp(weights) * r).detach().numpy()
-
-            # Log performance if requested and get_performance function is available
-            if log_csv:
-                performance_step = get_performance(
-                    final_weights,
-                    m_c,
-                    y_c,
-                    m_n,
-                    y_n,
-                    excluded_training_targets,
-                )
-                performance_step["epoch"] = epoch
-                performance_step["loss"] = performance_step.rel_abs_error**2
-                performance_step["target_name"] = [
-                    f"{area}/{metric}"
-                    for area, metric in zip(
-                        performance_step.name, performance_step.metric
-                    )
-                ]
-                performance = pd.concat(
-                    [performance, performance_step], ignore_index=True
-                )
-                performance.to_csv(log_csv, index=False)
-
-            # Save weights
-            with h5py.File(STORAGE_FOLDER / weight_file, "w") as f:
-                f.create_dataset(dataset_key, data=final_weights)
-
-            dataset.household.household_weight = final_weights.sum(axis=0)
-
+    dataset.household.household_weight = final_weights.sum(axis=0)
     return dataset

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -4,7 +4,9 @@ import numpy as np
 
 app = modal.App("policyengine-uk-calibration")
 
-image = modal.Image.debian_slim().pip_install("torch", "numpy", "h5py", "pandas")
+image = modal.Image.debian_slim().pip_install(
+    "torch", "numpy", "h5py", "pandas"
+)
 
 
 @app.function(gpu="T4", image=image, timeout=3600)

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -11,7 +11,11 @@ image_gpu = modal.Image.debian_slim().pip_install(
 image_cpu = (
     modal.Image.debian_slim(python_version="3.13")
     .apt_install("libhdf5-dev", "pkg-config", "gcc")
-    .pip_install("policyengine-uk-data>=1.40.0", "tables")
+    .uv_pip_install(
+        "torch",
+        extra_options="--index-url https://download.pytorch.org/whl/cpu",
+    )
+    .uv_pip_install("policyengine-uk-data>=1.40.0", "tables")
 )
 
 

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -21,8 +21,8 @@ image_cpu = (
 
 
 @app.function(
-    cpu=8,
-    memory=16384,
+    cpu=16,
+    memory=32768,
     image=image_cpu,
     timeout=3600,
     serialized=True,
@@ -70,7 +70,7 @@ def run_imputation(frs_bytes: bytes, year: int = 2023) -> bytes:
     return open(out_path, "rb").read()
 
 
-@app.function(gpu="T4", image=image_gpu, timeout=3600, serialized=True)
+@app.function(gpu="A10G", image=image_gpu, timeout=3600, serialized=True)
 def run_calibration(
     matrix: bytes,
     y: bytes,

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -13,7 +13,8 @@ image_cpu = (
     .apt_install("libhdf5-dev", "pkg-config", "gcc")
     .uv_pip_install(
         "torch",
-        extra_options="--index-url https://download.pytorch.org/whl/cpu",
+        index_url="https://download.pytorch.org/whl/cpu",
+        extra_index_url="https://pypi.org/simple/",
     )
     .uv_pip_install("policyengine-uk-data>=1.40.0", "tables")
 )

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -13,7 +13,7 @@ image_cpu = (
     .apt_install("libhdf5-dev", "pkg-config", "gcc")
     .run_commands(
         "pip install torch --index-url https://download.pytorch.org/whl/cpu",
-        "pip install policyengine-uk-data>=1.40.0 policyengine-uk tables",
+        "pip install policyengine-uk policyengine-uk-data>=1.40.0 tables microimpute",
     )
 )
 
@@ -23,6 +23,7 @@ image_cpu = (
     memory=16384,
     image=image_cpu,
     timeout=3600,
+    serialized=True,
 )
 def run_imputation(frs_bytes: bytes, year: int = 2023) -> bytes:
     """

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -1,0 +1,94 @@
+import io
+import modal
+import numpy as np
+
+app = modal.App("policyengine-uk-calibration")
+
+image = modal.Image.debian_slim().pip_install("torch", "numpy", "h5py", "pandas")
+
+
+@app.function(gpu="T4", image=image, timeout=3600)
+def run_calibration(
+    matrix: bytes,
+    y: bytes,
+    r: bytes,
+    matrix_national: bytes,
+    y_national: bytes,
+    weights_init: bytes,
+    epochs: int,
+) -> bytes:
+    """
+    Run the Adam calibration loop on a GPU container. All arrays are
+    serialised with ``np.save`` / deserialised with ``np.load``.
+
+    Returns the final weights (area_count × n_households) as np.save bytes.
+    """
+    import io
+    import numpy as np
+    import torch
+
+    # Inline _run_optimisation to keep the Modal image dependency-free
+    # (no policyengine_uk_data import needed inside the container).
+
+    def load(b):
+        return np.load(io.BytesIO(b))
+
+    matrix_np = load(matrix)
+    y_np = load(y)
+    r_np = load(r)
+    matrix_national_np = load(matrix_national)
+    y_national_np = load(y_national)
+    weights_init_np = load(weights_init)
+
+    device = torch.device("cuda")
+
+    metrics = torch.tensor(matrix_np, dtype=torch.float32, device=device)
+    y_t = torch.tensor(y_np, dtype=torch.float32, device=device)
+    m_national = torch.tensor(
+        matrix_national_np, dtype=torch.float32, device=device
+    )
+    y_nat = torch.tensor(y_national_np, dtype=torch.float32, device=device)
+    r_t = torch.tensor(r_np, dtype=torch.float32, device=device)
+
+    weights = torch.tensor(
+        weights_init_np,
+        dtype=torch.float32,
+        device=device,
+        requires_grad=True,
+    )
+
+    def sre(x, y_ref):
+        one_way = ((1 + x) / (1 + y_ref) - 1) ** 2
+        other_way = ((1 + y_ref) / (1 + x) - 1) ** 2
+        return torch.min(one_way, other_way)
+
+    def loss_fn(w):
+        pred_local = (w.unsqueeze(-1) * metrics.unsqueeze(0)).sum(dim=1)
+        mse_local = torch.mean(sre(pred_local, y_t))
+        pred_national = (w.sum(axis=0) * m_national.T).sum(axis=1)
+        mse_national = torch.mean(sre(pred_national, y_nat))
+        return mse_local + mse_national
+
+    def dropout_weights(w, p):
+        if p == 0:
+            return w
+        mask = torch.rand_like(w) < p
+        mean = w[~mask].mean()
+        w2 = w.clone()
+        w2[mask] = mean
+        return w2
+
+    optimizer = torch.optim.Adam([weights], lr=1e-1)
+
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        weights_ = torch.exp(dropout_weights(weights, 0.05)) * r_t
+        l = loss_fn(weights_)
+        l.backward()
+        optimizer.step()
+
+    final_weights = (torch.exp(weights) * r_t).detach().cpu().numpy()
+
+    buf = io.BytesIO()
+    np.save(buf, final_weights)
+    return buf.getvalue()

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -81,16 +81,19 @@ def run_calibration(
         return w2
 
     optimizer = torch.optim.Adam([weights], lr=1e-1)
+    checkpoints = []
 
-    for _ in range(epochs):
+    for epoch in range(epochs):
         optimizer.zero_grad()
         weights_ = torch.exp(dropout_weights(weights, 0.05)) * r_t
         l = loss_fn(weights_)
         l.backward()
         optimizer.step()
 
-    final_weights = (torch.exp(weights) * r_t).detach().cpu().numpy()
+        if epoch % 10 == 0:
+            w = (torch.exp(weights) * r_t).detach().cpu().numpy()
+            buf = io.BytesIO()
+            np.save(buf, w)
+            checkpoints.append((epoch, buf.getvalue()))
 
-    buf = io.BytesIO()
-    np.save(buf, final_weights)
-    return buf.getvalue()
+    return checkpoints

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -9,9 +9,9 @@ image_gpu = modal.Image.debian_slim().pip_install(
 )
 
 image_cpu = (
-    modal.Image.debian_slim()
+    modal.Image.debian_slim(python_version="3.13")
     .apt_install("libhdf5-dev", "pkg-config", "gcc")
-    .pip_install("policyengine-uk-data>=1.40.0")
+    .pip_install("policyengine-uk-data>=1.40.0", "tables")
 )
 
 

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -14,8 +14,9 @@ image_cpu = (
     .run_commands("pip install uv")
     .run_commands(
         "uv pip install --system torch --index-url https://download.pytorch.org/whl/cpu",
-        "uv pip install --system policyengine-uk policyengine-uk-data>=1.40.0 tables",
+        "uv pip install --system policyengine-uk tables microimpute",
     )
+    .copy_local_dir("policyengine_uk_data", "/root/policyengine_uk_data")
 )
 
 

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -11,9 +11,10 @@ image_gpu = modal.Image.debian_slim().pip_install(
 image_cpu = (
     modal.Image.debian_slim(python_version="3.13")
     .apt_install("libhdf5-dev", "pkg-config", "gcc")
+    .run_commands("pip install uv")
     .run_commands(
-        "pip install torch --index-url https://download.pytorch.org/whl/cpu",
-        "pip install policyengine-uk policyengine-uk-data>=1.40.0 tables microimpute",
+        "uv pip install --system torch --index-url https://download.pytorch.org/whl/cpu",
+        "uv pip install --system policyengine-uk policyengine-uk-data>=1.40.0 tables",
     )
 )
 

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -9,7 +9,7 @@ image = modal.Image.debian_slim().pip_install(
 )
 
 
-@app.function(gpu="T4", image=image, timeout=3600)
+@app.function(gpu="T4", image=image, timeout=3600, serialized=True)
 def run_calibration(
     matrix: bytes,
     y: bytes,

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -16,7 +16,7 @@ image_cpu = (
         "uv pip install --system torch --index-url https://download.pytorch.org/whl/cpu",
         "uv pip install --system policyengine-uk tables microimpute",
     )
-    .copy_local_dir("policyengine_uk_data", "/root/policyengine_uk_data")
+    .add_local_dir("policyengine_uk_data", "/root/policyengine_uk_data")
 )
 
 

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -11,12 +11,10 @@ image_gpu = modal.Image.debian_slim().pip_install(
 image_cpu = (
     modal.Image.debian_slim(python_version="3.13")
     .apt_install("libhdf5-dev", "pkg-config", "gcc")
-    .uv_pip_install(
-        "torch",
-        index_url="https://download.pytorch.org/whl/cpu",
-        extra_index_url="https://pypi.org/simple/",
+    .run_commands(
+        "pip install torch --index-url https://download.pytorch.org/whl/cpu",
+        "pip install policyengine-uk-data>=1.40.0 policyengine-uk tables",
     )
-    .uv_pip_install("policyengine-uk-data>=1.40.0", "tables")
 )
 
 

--- a/policyengine_uk_data/utils/modal_calibrate.py
+++ b/policyengine_uk_data/utils/modal_calibrate.py
@@ -8,9 +8,10 @@ image_gpu = modal.Image.debian_slim().pip_install(
     "torch", "numpy", "h5py", "pandas"
 )
 
-image_cpu = modal.Image.debian_slim().pip_install(
-    "policyengine-uk-data>=1.39.3",
-    "tables",
+image_cpu = (
+    modal.Image.debian_slim()
+    .apt_install("libhdf5-dev", "pkg-config", "gcc")
+    .pip_install("policyengine-uk-data>=1.40.0")
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "itables",
     "quantile-forest",
     "build",
+    "modal",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- Offload the Adam optimisation loop to Modal T4 GPU containers
- Both calibrations (650 constituencies, 360 LAs) run in parallel, so wall time is max(c_time, la_time) rather than the sum
- CPU fallback unchanged when `MODAL_CALIBRATE` is not set

## Changes
- `calibrate.py`: extract `_run_optimisation()` helper (device-agnostic); `calibrate_local_areas` delegates to it on CPU as before
- `modal_calibrate.py` (new): Modal app with `run_calibration` function on `gpu="T4"`, self-contained loop (no policyengine imports in container)
- `create_datasets.py`: when `MODAL_CALIBRATE=1`, build arrays locally, `.spawn()` both GPU jobs before waiting on either, then write `.h5` files
- `push.yaml` / `pull_request.yaml`: add `MODAL_CALIBRATE=1` + `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` secrets to Build datasets step
- `pyproject.toml`: add `modal` to `dev` extras

## Test plan
- [ ] CI passes with `MODAL_CALIBRATE=1` (tokens set as repo secrets)
- [ ] Local CPU run (`make data` without `MODAL_CALIBRATE`) is unchanged
- [ ] Both `.h5` weight files are produced and `make test` passes