### PR TITLE
Fix versioning workflow: use GitHub App token instead of expired PAT

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -16,10 +16,16 @@ jobs:
         if: |
           (!(github.event.head_commit.message == 'Update package version'))
         steps:
+            - name: Generate GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                app-id: ${{ secrets.APP_ID }}
+                private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout repo
               uses: actions/checkout@v4
               with:
-                token: ${{ secrets.POLICYENGINE_GITHUB }}
+                token: ${{ steps.app-token.outputs.token }}
                 fetch-depth: 0
             - name: Setup Python
               uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- The `POLICYENGINE_GITHUB` personal access token expired, causing the versioning workflow to fail on every merge to `main` ([example run](https://github.com/PolicyEngine/policyengine-uk-data/actions/runs/23144472164))
- Replaces the PAT with a short-lived token generated via `actions/create-github-app-token@v1` using the org's existing `APP_ID` and `APP_PRIVATE_KEY` secrets
- More secure: no dependency on any individual's personal account, tokens are short-lived and scoped

## Test plan
- [ ] Merge this PR and verify the versioning workflow succeeds on the resulting push to `main`
- [ ] Check that the changelog and version bump commit is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)