### PR TITLE
Preserve raw age data and document original sources

### DIFF
--- a/changelog.d/preserve-raw-age-data.changed.md
+++ b/changelog.d/preserve-raw-age-data.changed.md
@@ -1,0 +1,1 @@
+Updated age data pipeline to read from `raw_age.csv` and write processed output to `age.csv`, preserving original data. Documented original sources in READMEs.

--- a/policyengine_uk_data/datasets/local_areas/constituencies/targets/README.md
+++ b/policyengine_uk_data/datasets/local_areas/constituencies/targets/README.md
@@ -1,6 +1,5 @@
 # Data
 
-* Age is from [the ONS](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.ons.gov.uk/file%3Furi%3D/peoplepopulationandcommunity/populationandmigration/populationestimates/datasets/parliamentaryconstituencymidyearpopulationestimates/mid2020sape23dt7/sape23dt7mid2020parliconsyoaestimatesunformatted.xlsx&ved=2ahUKEwifosm3x9GIAxXxQkEAHU_LB70QFnoECBgQAQ&usg=AOvVaw0-MdplttsD8klJR6M3WID8) and has single-year age counts for each political constituency (2010) in the UK. The data is from 2020.
+* Age data is from the [House of Commons Library](https://commonslibrary.parliament.uk/constituency-statistics-population-by-age/), with single-year age counts for each parliamentary constituency (2010). The data is from 2020. The raw download should be saved as `raw_age.csv`; running `fill_missing_age_demographics.py` fills in missing Scotland and NI constituencies using mean age profiles and writes the processed output to `age.csv`.
 * Employment incomes are from Nomis, and are from 2023.
 * HMRC total income is from 2021.
-

--- a/policyengine_uk_data/datasets/local_areas/constituencies/targets/fill_missing_age_demographics.py
+++ b/policyengine_uk_data/datasets/local_areas/constituencies/targets/fill_missing_age_demographics.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-ages = pd.read_csv("age.csv")
+ages = pd.read_csv("raw_age.csv")
 incomes = pd.read_csv("total_income.csv")
 
 ENGLAND_CONSTITUENCY = "E14"

--- a/policyengine_uk_data/datasets/local_areas/local_authorities/targets/README.md
+++ b/policyengine_uk_data/datasets/local_areas/local_authorities/targets/README.md
@@ -1,6 +1,5 @@
 # Data
 
-* Age is from [the ONS](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.ons.gov.uk/file%3Furi%3D/peoplepopulationandcommunity/populationandmigration/populationestimates/datasets/parliamentaryconstituencymidyearpopulationestimates/mid2020sape23dt7/sape23dt7mid2020parliconsyoaestimatesunformatted.xlsx&ved=2ahUKEwifosm3x9GIAxXxQkEAHU_LB70QFnoECBgQAQ&usg=AOvVaw0-MdplttsD8klJR6M3WID8) and has single-year age counts for each political constituency (2010) in the UK. The data is from 2020.
+* Age data is from the [ONS mid-year population estimates](https://www.nomisweb.co.uk/datasets/pestsyoala), with single-year age counts for each local authority district. The raw download should be saved as `raw_age.csv`; running `fill_missing_age_demographics.py` fills missing values and intersects with the income file, writing the processed output to `age.csv`.
 * Employment incomes are from Nomis, and are from 2023.
 * HMRC total income is from 2021.
-


### PR DESCRIPTION
## Summary
- Changed constituency `fill_missing_age_demographics.py` to read from `raw_age.csv` instead of `age.csv`, matching the existing LA script pattern. This prevents the script from overwriting the original data.
- Updated both READMEs to document the raw/processed file distinction and link to the original data sources (House of Commons Library for constituencies, ONS for local authorities).

Note: the raw data files (`raw_age.csv`) were never committed to the repo — the current `age.csv` files are already processed outputs. This PR ensures the pipeline is correct going forward when someone re-downloads fresh data.

Closes #71.

## Test plan
- [ ] Verify `fill_missing_age_demographics.py` reads from `raw_age.csv` in both directories
- [ ] Verify READMEs document the data sources and raw/processed distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)