### PR TITLE
Add policyengine-claude plugin auto-install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "marketplaces": [
+      "PolicyEngine/policyengine-claude"
+    ],
+    "auto_install": [
+      "country-models@policyengine-claude"
+    ]
+  }
+}

--- a/changelog.d/add-claude-plugin.added.md
+++ b/changelog.d/add-claude-plugin.added.md
@@ -1,0 +1,1 @@
+Added policyengine-claude plugin auto-install configuration.


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with auto-install config for the `country-models` plugin from [policyengine-claude](https://github.com/PolicyEngine/policyengine-claude)
- When you trust this repo in Claude Code, the plugin auto-installs, providing specialised agents, slash commands, and skills

Supersedes #263 (which has stale merge conflicts from the old `changelog_entry.yaml` format).

Closes #263.

## Test plan
- [ ] Trust the repo in Claude Code and verify the plugin install prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)