### PR TITLE
Fix energy raking: FY26/27 prices and weighted means

### DIFF
--- a/policyengine_uk_data/datasets/imputations/consumption.py
+++ b/policyengine_uk_data/datasets/imputations/consumption.py
@@ -12,7 +12,9 @@ Key features:
 - Housing predictors (tenure_type, accommodation_type) added alongside income
   and demographics, matching the strong drivers in NEED admin data.
 - Imputed totals are calibrated to NEED 2023 mean kWh targets by income band,
-  converted to spend using Ofgem Q4 2023 unit rates (Oct 2023 price cap).
+  converted to spend using Ofgem Q2 2026 unit rates (Apr 2026 price cap) so the
+  stored £/yr values represent FY26/27 price levels. Energy variables are not
+  CPI-uprated, so this avoids the need for price-level adjustment at simulation time.
   NEED income bands use Experian modelled gross household income, so calibration
   matches against gross income (LCFS P344p / FRS household_gross_income) rather
   than HBAI net income.
@@ -143,11 +145,13 @@ IMPUTATIONS = [
 # Source: NEED 2023 headline tables (published 2025), England & Wales, ~18M dwellings.
 # Tables 11b/12b: mean gas/electricity kWh by income; 9b/10b by tenure;
 # 5b/6b by property type; 15b/16b by region; 13b/14b by number of adults.
-# Converted to annual spend using Ofgem Q4 2023 (Oct 2023 price cap) unit rates.
-# 2023 is used rather than 2022 because 2022 was an extreme energy-price crisis year.
+# NEED kWh targets are physical consumption (stable across years). We convert to
+# annual spend using Ofgem Q2 2026 unit rates so the raked values represent
+# FY26/27 price levels. Energy variables are not CPI-uprated, so this ensures
+# the stored £/yr values are correct for the target simulation year.
 # Standing charges excluded to keep to unit-rate spend consistent with LCFS recording.
-OFGEM_Q4_2023_ELEC_RATE = 27.35 / 100  # £/kWh (Oct 2023 price cap)
-OFGEM_Q4_2023_GAS_RATE = 6.89 / 100  # £/kWh (Oct 2023 price cap)
+OFGEM_Q2_2026_ELEC_RATE = 24.67 / 100  # £/kWh (Apr 2026 price cap)
+OFGEM_Q2_2026_GAS_RATE = 5.74 / 100  # £/kWh (Apr 2026 price cap)
 
 # NEED 2023 mean kWh by income band (Table 11b gas, Table 12b electricity)
 # Income bands are gross household income (Experian modelled data)
@@ -234,26 +238,38 @@ NEED_REGION_ELEC = {
     "WALES": 3_151,
 }
 
-# Pre-computed NEED spend targets (£/yr) — kWh × unit rate, keyed by energy type.
-# Used in the raking loop of impute_consumption(); avoids recomputing each call.
+# Pre-computed NEED spend targets (£/yr at FY26/27 prices) — kWh × Ofgem Q2 2026
+# unit rate, keyed by energy type. Used in the raking loop of impute_consumption().
 _NEED_SPEND = {
     "electricity": {
         "income": [
-            (lo, hi, elec_kwh * OFGEM_Q4_2023_ELEC_RATE)
+            (lo, hi, elec_kwh * OFGEM_Q2_2026_ELEC_RATE)
             for lo, hi, _, _, elec_kwh in NEED_INCOME_BANDS
         ],
-        "tenure": {k: v * OFGEM_Q4_2023_ELEC_RATE for k, v in NEED_TENURE_ELEC.items()},
-        "accomm": {k: v * OFGEM_Q4_2023_ELEC_RATE for k, v in NEED_ACCOMM_ELEC.items()},
-        "region": {k: v * OFGEM_Q4_2023_ELEC_RATE for k, v in NEED_REGION_ELEC.items()},
+        "tenure": {
+            k: v * OFGEM_Q2_2026_ELEC_RATE for k, v in NEED_TENURE_ELEC.items()
+        },
+        "accomm": {
+            k: v * OFGEM_Q2_2026_ELEC_RATE for k, v in NEED_ACCOMM_ELEC.items()
+        },
+        "region": {
+            k: v * OFGEM_Q2_2026_ELEC_RATE for k, v in NEED_REGION_ELEC.items()
+        },
     },
     "gas": {
         "income": [
-            (lo, hi, gas_kwh * OFGEM_Q4_2023_GAS_RATE)
+            (lo, hi, gas_kwh * OFGEM_Q2_2026_GAS_RATE)
             for lo, hi, _, gas_kwh, _ in NEED_INCOME_BANDS
         ],
-        "tenure": {k: v * OFGEM_Q4_2023_GAS_RATE for k, v in NEED_TENURE_GAS.items()},
-        "accomm": {k: v * OFGEM_Q4_2023_GAS_RATE for k, v in NEED_ACCOMM_GAS.items()},
-        "region": {k: v * OFGEM_Q4_2023_GAS_RATE for k, v in NEED_REGION_GAS.items()},
+        "tenure": {
+            k: v * OFGEM_Q2_2026_GAS_RATE for k, v in NEED_TENURE_GAS.items()
+        },
+        "accomm": {
+            k: v * OFGEM_Q2_2026_GAS_RATE for k, v in NEED_ACCOMM_GAS.items()
+        },
+        "region": {
+            k: v * OFGEM_Q2_2026_GAS_RATE for k, v in NEED_REGION_GAS.items()
+        },
     },
 }
 
@@ -264,18 +280,18 @@ def _need_targets(income: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     elec_spend = np.full(len(income), np.nan)
     for lo, hi, _, gas_kwh, elec_kwh in NEED_INCOME_BANDS:
         mask = (income >= lo) & (income < hi)
-        gas_spend[mask] = gas_kwh * OFGEM_Q4_2023_GAS_RATE
-        elec_spend[mask] = elec_kwh * OFGEM_Q4_2023_ELEC_RATE
+        gas_spend[mask] = gas_kwh * OFGEM_Q2_2026_GAS_RATE
+        elec_spend[mask] = elec_kwh * OFGEM_Q2_2026_ELEC_RATE
     # Fill any missing with overall means
     overall_gas = (
         sum(g for *_, g, _ in NEED_INCOME_BANDS)
         / len(NEED_INCOME_BANDS)
-        * OFGEM_Q4_2023_GAS_RATE
+        * OFGEM_Q2_2026_GAS_RATE
     )
     overall_elec = (
         sum(e for *_, e in NEED_INCOME_BANDS)
         / len(NEED_INCOME_BANDS)
-        * OFGEM_Q4_2023_ELEC_RATE
+        * OFGEM_Q2_2026_ELEC_RATE
     )
     gas_spend = np.where(np.isnan(gas_spend), overall_gas, gas_spend)
     elec_spend = np.where(np.isnan(elec_spend), overall_elec, elec_spend)
@@ -309,7 +325,9 @@ def _derive_energy_from_lcfs(household: pd.DataFrame) -> pd.DataFrame:
     dd_mask = (b226 > 0) & (p537 > 0)
     mean_elec_share = (b226[dd_mask] / p537[dd_mask]).clip(0, 1).mean()
     if np.isnan(mean_elec_share):
-        mean_elec_share = 0.52  # fallback: typical UK elec/(elec+gas) spend share
+        mean_elec_share = (
+            0.52  # fallback: typical UK elec/(elec+gas) spend share
+        )
 
     electricity = np.zeros(len(household))
     gas = np.zeros(len(household))
@@ -344,7 +362,8 @@ def _calibrate_energy_to_need(
     household: pd.DataFrame, income_col: str = "household_gross_income"
 ) -> pd.DataFrame:
     """
-    Rescale imputed electricity and gas spend to match NEED 2023 income-band means.
+    Rescale imputed electricity and gas spend to match NEED 2023 income-band means
+    at FY26/27 price levels (Ofgem Q2 2026 rates).
 
     NEED 2023 income bands use Experian modelled gross household income, so we
     match against gross income rather than HBAI net income.
@@ -367,7 +386,9 @@ def _calibrate_energy_to_need(
         need_elec_mean = elec_target[mask].mean()
 
         if lcfs_gas_mean > 0:
-            household.loc[mask, "gas_consumption"] *= need_gas_mean / lcfs_gas_mean
+            household.loc[mask, "gas_consumption"] *= (
+                need_gas_mean / lcfs_gas_mean
+            )
         if lcfs_elec_mean > 0:
             household.loc[mask, "electricity_consumption"] *= (
                 need_elec_mean / lcfs_elec_mean
@@ -449,13 +470,15 @@ def impute_has_fuel_to_lcfs(household: pd.DataFrame) -> pd.DataFrame:
     )
     output_df = model.predict(input_df)
     household = household.copy()
-    household["has_fuel_consumption"] = output_df["has_fuel_consumption"].values.clip(
-        0, 1
-    )
+    household["has_fuel_consumption"] = output_df[
+        "has_fuel_consumption"
+    ].values.clip(0, 1)
     return household
 
 
-def generate_lcfs_table(lcfs_person: pd.DataFrame, lcfs_household: pd.DataFrame):
+def generate_lcfs_table(
+    lcfs_person: pd.DataFrame, lcfs_household: pd.DataFrame
+):
     """
     Build the LCFS training table for consumption imputation.
 
@@ -469,7 +492,9 @@ def generate_lcfs_table(lcfs_person: pd.DataFrame, lcfs_household: pd.DataFrame)
 
     # Housing predictors — map LCFS codes to FRS enum strings
     household["tenure_type"] = lcfs_household["A122"].map(LCFS_TENURE_MAP)
-    household["accommodation_type"] = lcfs_household["A121"].map(LCFS_ACCOMM_MAP)
+    household["accommodation_type"] = lcfs_household["A121"].map(
+        LCFS_ACCOMM_MAP
+    )
 
     # Derive gas and electricity before renaming/annualising P537
     household = _derive_energy_from_lcfs(household)
@@ -497,10 +522,14 @@ def generate_lcfs_table(lcfs_person: pd.DataFrame, lcfs_household: pd.DataFrame)
     # Impute has_fuel_consumption from WAS vehicle ownership
     household = impute_has_fuel_to_lcfs(household)
 
-    return household[PREDICTOR_VARIABLES + IMPUTATIONS + ["household_weight"]].dropna()
+    return household[
+        PREDICTOR_VARIABLES + IMPUTATIONS + ["household_weight"]
+    ].dropna()
 
 
-def uprate_lcfs_table(household: pd.DataFrame, time_period: str) -> pd.DataFrame:
+def uprate_lcfs_table(
+    household: pd.DataFrame, time_period: str
+) -> pd.DataFrame:
     from policyengine_uk.system import system
 
     start_period = 2021
@@ -508,7 +537,9 @@ def uprate_lcfs_table(household: pd.DataFrame, time_period: str) -> pd.DataFrame
     household["petrol_spending"] *= fuel_uprating
     household["diesel_spending"] *= fuel_uprating
 
-    cpi = system.parameters.gov.economic_assumptions.indices.obr.consumer_price_index
+    cpi = (
+        system.parameters.gov.economic_assumptions.indices.obr.consumer_price_index
+    )
     cpi_uprating = cpi(time_period) / cpi(start_period)
 
     energy_vars = {
@@ -557,7 +588,9 @@ def save_imputation_models():
 def create_consumption_model(overwrite_existing: bool = False):
     from policyengine_uk_data.utils.qrf import QRF
 
-    if (STORAGE_FOLDER / "consumption.pkl").exists() and not overwrite_existing:
+    if (
+        STORAGE_FOLDER / "consumption.pkl"
+    ).exists() and not overwrite_existing:
         return QRF(file_path=STORAGE_FOLDER / "consumption.pkl")
     return save_imputation_models()
 
@@ -581,7 +614,9 @@ def impute_consumption(dataset: UKSingleYearDataset) -> UKSingleYearDataset:
     model = create_consumption_model()
     predictors = model.input_columns
 
-    non_fuel_predictors = [p for p in predictors if p != "has_fuel_consumption"]
+    non_fuel_predictors = [
+        p for p in predictors if p != "has_fuel_consumption"
+    ]
     input_df = sim.calculate_dataframe(non_fuel_predictors, map_to="household")
     input_df["has_fuel_consumption"] = has_fuel_consumption
 
@@ -589,25 +624,35 @@ def impute_consumption(dataset: UKSingleYearDataset) -> UKSingleYearDataset:
     for column in output_df.columns:
         dataset.household[column] = output_df[column].values
 
-    # Re-calibrate electricity and gas to NEED 2023 targets using iterative raking
-    # over income band, tenure, accommodation type, and region.
-    # This is a 4-dimensional raking (vs the 1D income-band calibration on LCFS
-    # training data in _calibrate_energy_to_need) because the FRS has the full
-    # set of housing/demographic variables needed for multi-margin calibration.
+    # Re-calibrate electricity and gas to NEED 2023 kWh targets (converted to
+    # FY26/27 £ at Ofgem Q2 2026 rates) using iterative raking over income band,
+    # tenure, accommodation type, and region. Energy variables are not CPI-uprated,
+    # so raking at the target-year price level ensures stored £/yr values are
+    # correct for the simulation year without further adjustment.
     # NEED income bands use Experian modelled gross income, so we use
     # household_gross_income rather than hbai_household_net_income.
     income = sim.calculate("household_gross_income", map_to="household").values
     tenure = sim.calculate("tenure_type", map_to="household").values
     accomm = sim.calculate("accommodation_type", map_to="household").values
     region = sim.calculate("region", map_to="household").values
+    weights = sim.calculate("household_weight", map_to="household").values
 
-    # Pre-compute boolean masks (reused across 20 raking iterations)
+    # Pre-compute boolean masks (reused across raking iterations)
     income_masks = []
     for lo, hi, _ in _NEED_SPEND["electricity"]["income"]:
         income_masks.append((income >= lo) & (income < hi))
     tenure_masks = {frs_val: tenure == frs_val for frs_val in TENURE_TO_NEED}
     accomm_masks = {frs_val: accomm == frs_val for frs_val in ACCOMM_TO_NEED}
-    region_masks = {reg: region == reg for reg in _NEED_SPEND["electricity"]["region"]}
+    region_masks = {
+        reg: region == reg for reg in _NEED_SPEND["electricity"]["region"]
+    }
+
+    def _wmean(arr, mask):
+        w = weights[mask]
+        total_w = w.sum()
+        if total_w == 0:
+            return 0.0
+        return (arr[mask] * w).sum() / total_w
 
     for energy, col in [
         ("electricity", "electricity_consumption"),
@@ -615,27 +660,31 @@ def impute_consumption(dataset: UKSingleYearDataset) -> UKSingleYearDataset:
     ]:
         targets = _NEED_SPEND[energy]
         arr = dataset.household[col].values.copy()
-        for _ in range(20):  # iterative raking — converges in ~10 passes
+        for _ in range(50):  # iterative raking
             for i, (_, _, target) in enumerate(targets["income"]):
                 mask = income_masks[i]
-                if mask.sum() > 0 and arr[mask].mean() > 0:
-                    arr[mask] *= target / arr[mask].mean()
+                wm = _wmean(arr, mask)
+                if mask.sum() > 0 and wm > 0:
+                    arr[mask] *= target / wm
             for frs_val, need_key in TENURE_TO_NEED.items():
                 if need_key not in targets["tenure"]:
                     continue
                 mask = tenure_masks[frs_val]
-                if mask.sum() > 0 and arr[mask].mean() > 0:
-                    arr[mask] *= targets["tenure"][need_key] / arr[mask].mean()
+                wm = _wmean(arr, mask)
+                if mask.sum() > 0 and wm > 0:
+                    arr[mask] *= targets["tenure"][need_key] / wm
             for frs_val, need_key in ACCOMM_TO_NEED.items():
                 if need_key not in targets["accomm"]:
                     continue
                 mask = accomm_masks[frs_val]
-                if mask.sum() > 0 and arr[mask].mean() > 0:
-                    arr[mask] *= targets["accomm"][need_key] / arr[mask].mean()
+                wm = _wmean(arr, mask)
+                if mask.sum() > 0 and wm > 0:
+                    arr[mask] *= targets["accomm"][need_key] / wm
             for reg_val, target in targets["region"].items():
                 mask = region_masks[reg_val]
-                if mask.sum() > 0 and arr[mask].mean() > 0:
-                    arr[mask] *= target / arr[mask].mean()
+                wm = _wmean(arr, mask)
+                if mask.sum() > 0 and wm > 0:
+                    arr[mask] *= target / wm
         dataset.household[col] = arr
 
     # Zero out car-fuel spending for non-ICE households

--- a/policyengine_uk_data/tests/test_energy_calibration.py
+++ b/policyengine_uk_data/tests/test_energy_calibration.py
@@ -5,7 +5,7 @@ type, and region.
 
 Runs impute_consumption() on the base FRS (post-wealth imputation) so the
 test reflects what the QRF + raking calibration actually produces for real
-FRS households at 2023 price levels.
+FRS households at FY26/27 price levels (Ofgem Q2 2026 rates).
 """
 
 import numpy as np
@@ -22,15 +22,17 @@ from policyengine_uk_data.datasets.imputations.consumption import (
     NEED_REGION_GAS,
     NEED_TENURE_ELEC,
     NEED_TENURE_GAS,
-    OFGEM_Q4_2023_ELEC_RATE,
-    OFGEM_Q4_2023_GAS_RATE,
+    OFGEM_Q2_2026_ELEC_RATE,
+    OFGEM_Q2_2026_GAS_RATE,
     TENURE_TO_NEED,
     impute_consumption,
 )
 from policyengine_uk_data.datasets.imputations.wealth import impute_wealth
 from policyengine_uk_data.storage import STORAGE_FOLDER
 
-BAND_TOL = 0.11  # 11% per cell (raking tension between dimensions can push ~10%)
+BAND_TOL = (
+    0.11  # 11% per cell (raking tension between dimensions can push ~10%)
+)
 HIGH_INC_TOL = 0.15  # 15% for £100k+ bands (thin FRS sample, raking tension)
 
 
@@ -52,7 +54,9 @@ def arrays(imputed):
         income=sim.calculate(
             "household_gross_income", map_to="household", period=2023
         ).values,
-        tenure=sim.calculate("tenure_type", map_to="household", period=2023).values,
+        tenure=sim.calculate(
+            "tenure_type", map_to="household", period=2023
+        ).values,
         accomm=sim.calculate(
             "accommodation_type", map_to="household", period=2023
         ).values,
@@ -72,16 +76,16 @@ def _wmean(values, weights):
 def _check(label, rows):
     _print_table(label, rows)
     for band, imputed, target, pct_err in rows:
-        assert pct_err < BAND_TOL, (
-            f"{label} [{band}]: imputed {imputed:.0f} vs NEED {target:.0f} ({pct_err:.1%})"
-        )
+        assert (
+            pct_err < BAND_TOL
+        ), f"{label} [{band}]: imputed {imputed:.0f} vs NEED {target:.0f} ({pct_err:.1%})"
 
 
 def test_electricity_by_income(arrays):
     elec, income, w = arrays["elec"], arrays["income"], arrays["weights"]
     rows = []
     for lo, hi, band, _, elec_kwh in NEED_INCOME_BANDS:
-        target = elec_kwh * OFGEM_Q4_2023_ELEC_RATE
+        target = elec_kwh * OFGEM_Q2_2026_ELEC_RATE
         mask = (income >= lo) & (income < hi)
         if mask.sum() == 0:
             continue
@@ -93,34 +97,36 @@ def test_electricity_by_income(arrays):
         [(b, i, t, e) for b, i, t, e, _ in rows],
     )
     for band, imp, target, pct_err, tol in rows:
-        assert pct_err < tol, (
-            f"Electricity by income [{band}]: {imp:.0f} vs {target:.0f} ({pct_err:.1%})"
-        )
+        assert (
+            pct_err < tol
+        ), f"Electricity by income [{band}]: {imp:.0f} vs {target:.0f} ({pct_err:.1%})"
 
 
 def test_gas_by_income(arrays):
     gas, income, w = arrays["gas"], arrays["income"], arrays["weights"]
     rows = []
     for lo, hi, band, gas_kwh, _ in NEED_INCOME_BANDS:
-        target = gas_kwh * OFGEM_Q4_2023_GAS_RATE
+        target = gas_kwh * OFGEM_Q2_2026_GAS_RATE
         mask = (income >= lo) & (income < hi)
         if mask.sum() == 0:
             continue
         imp = _wmean(gas[mask], w[mask])
         tol = HIGH_INC_TOL if lo >= 100_000 else BAND_TOL
         rows.append((band, imp, target, abs(imp - target) / target, tol))
-    _print_table("Gas £/yr by income band", [(b, i, t, e) for b, i, t, e, _ in rows])
+    _print_table(
+        "Gas £/yr by income band", [(b, i, t, e) for b, i, t, e, _ in rows]
+    )
     for band, imp, target, pct_err, tol in rows:
-        assert pct_err < tol, (
-            f"Gas by income [{band}]: {imp:.0f} vs {target:.0f} ({pct_err:.1%})"
-        )
+        assert (
+            pct_err < tol
+        ), f"Gas by income [{band}]: {imp:.0f} vs {target:.0f} ({pct_err:.1%})"
 
 
 def test_electricity_by_tenure(arrays):
     elec, tenure, w = arrays["elec"], arrays["tenure"], arrays["weights"]
     rows = []
     for frs_val, need_key in TENURE_TO_NEED.items():
-        target = NEED_TENURE_ELEC[need_key] * OFGEM_Q4_2023_ELEC_RATE
+        target = NEED_TENURE_ELEC[need_key] * OFGEM_Q2_2026_ELEC_RATE
         mask = tenure == frs_val
         if mask.sum() == 0:
             continue
@@ -133,7 +139,7 @@ def test_gas_by_tenure(arrays):
     gas, tenure, w = arrays["gas"], arrays["tenure"], arrays["weights"]
     rows = []
     for frs_val, need_key in TENURE_TO_NEED.items():
-        target = NEED_TENURE_GAS[need_key] * OFGEM_Q4_2023_GAS_RATE
+        target = NEED_TENURE_GAS[need_key] * OFGEM_Q2_2026_GAS_RATE
         mask = tenure == frs_val
         if mask.sum() == 0:
             continue
@@ -146,7 +152,7 @@ def test_electricity_by_accommodation(arrays):
     elec, accomm, w = arrays["elec"], arrays["accomm"], arrays["weights"]
     rows = []
     for frs_val, need_key in ACCOMM_TO_NEED.items():
-        target = NEED_ACCOMM_ELEC[need_key] * OFGEM_Q4_2023_ELEC_RATE
+        target = NEED_ACCOMM_ELEC[need_key] * OFGEM_Q2_2026_ELEC_RATE
         mask = accomm == frs_val
         if mask.sum() == 0:
             continue
@@ -159,7 +165,7 @@ def test_gas_by_accommodation(arrays):
     gas, accomm, w = arrays["gas"], arrays["accomm"], arrays["weights"]
     rows = []
     for frs_val, need_key in ACCOMM_TO_NEED.items():
-        target = NEED_ACCOMM_GAS[need_key] * OFGEM_Q4_2023_GAS_RATE
+        target = NEED_ACCOMM_GAS[need_key] * OFGEM_Q2_2026_GAS_RATE
         mask = accomm == frs_val
         if mask.sum() == 0:
             continue
@@ -172,7 +178,7 @@ def test_electricity_by_region(arrays):
     elec, region, w = arrays["elec"], arrays["region"], arrays["weights"]
     rows = []
     for reg, target_kwh in NEED_REGION_ELEC.items():
-        target = target_kwh * OFGEM_Q4_2023_ELEC_RATE
+        target = target_kwh * OFGEM_Q2_2026_ELEC_RATE
         mask = region == reg
         if mask.sum() == 0:
             continue
@@ -185,7 +191,7 @@ def test_gas_by_region(arrays):
     gas, region, w = arrays["gas"], arrays["region"], arrays["weights"]
     rows = []
     for reg, target_kwh in NEED_REGION_GAS.items():
-        target = target_kwh * OFGEM_Q4_2023_GAS_RATE
+        target = target_kwh * OFGEM_Q2_2026_GAS_RATE
         mask = region == reg
         if mask.sum() == 0:
             continue
@@ -198,7 +204,9 @@ def test_non_negative_energy(imputed):
     """All households should have non-negative electricity and gas spend."""
     elec = imputed.household["electricity_consumption"].values
     gas = imputed.household["gas_consumption"].values
-    assert (elec >= 0).all(), f"{(elec < 0).sum()} households have negative electricity"
+    assert (
+        elec >= 0
+    ).all(), f"{(elec < 0).sum()} households have negative electricity"
     assert (gas >= 0).all(), f"{(gas < 0).sum()} households have negative gas"
 
 
@@ -208,10 +216,10 @@ def test_national_mean(arrays):
     # NEED 2023 overall mean: unweighted average across income bands as proxy
     need_elec_national = (
         sum(e for *_, e in NEED_INCOME_BANDS) / len(NEED_INCOME_BANDS)
-    ) * OFGEM_Q4_2023_ELEC_RATE
+    ) * OFGEM_Q2_2026_ELEC_RATE
     need_gas_national = (
         sum(g for *_, g, _ in NEED_INCOME_BANDS) / len(NEED_INCOME_BANDS)
-    ) * OFGEM_Q4_2023_GAS_RATE
+    ) * OFGEM_Q2_2026_GAS_RATE
 
     imp_elec = _wmean(arrays["elec"], w)
     imp_gas = _wmean(arrays["gas"], w)
@@ -256,5 +264,7 @@ def _print_table(title, rows):
     print(f"  {'─' * 26} {'─' * 10} {'─' * 10} {'─' * 8}")
     for group, imp, target, pct_err in rows:
         flag = " !" if pct_err >= BAND_TOL else ""
-        print(f"  {str(group):<26} {imp:>10.0f} {target:>10.0f} {pct_err:>7.1%}{flag}")
+        print(
+            f"  {str(group):<26} {imp:>10.0f} {target:>10.0f} {pct_err:>7.1%}{flag}"
+        )
     print(f"{'─' * 68}")


### PR DESCRIPTION
## Summary

- Replace Ofgem Q4 2023 unit rates (27.35p/kWh elec, 6.89p/kWh gas) with Q2 2026 rates (24.67p/kWh elec, 5.74p/kWh gas) for converting NEED kWh targets to £ spend. Since energy variables are not CPI-uprated, this ensures raked £/yr values represent FY26/27 price levels — correct for the target simulation year without further adjustment.
- Use `household_weight` in the 4D raking loop (weighted means) instead of unweighted means, matching NEED population-level targets and fixing a convergence bias.
- Increase raking iterations from 20 to 50 for better convergence across the four dimensions (income × tenure × accommodation × region).