### PR TITLE
Remove property_wealth from land calibration targets

### DIFF
--- a/changelog.d/fix-land-value-target-scope.fixed.md
+++ b/changelog.d/fix-land-value-target-scope.fixed.md
@@ -1,0 +1,1 @@
+Remove the incorrect `property_wealth` land calibration target and keep only direct land-value targets from the ONS National Balance Sheet.

--- a/policyengine_uk_data/targets/build_loss_matrix.py
+++ b/policyengine_uk_data/targets/build_loss_matrix.py
@@ -295,7 +295,6 @@ def _compute_column(target: Target, ctx: _SimContext, year: int) -> np.ndarray |
         "ons/household_land_value",
         "ons/corporate_land_value",
         "ons/land_value",
-        "ons/property_wealth",
     ):
         return compute_land_value(target, ctx)
 

--- a/policyengine_uk_data/targets/sources/ons_land_values.py
+++ b/policyengine_uk_data/targets/sources/ons_land_values.py
@@ -68,16 +68,4 @@ def get_targets() -> list[Target]:
             },
             reference_url=_REF_URL,
         ),
-        Target(
-            name="ons/property_wealth",
-            variable="property_wealth",
-            source="ons",
-            unit=Unit.GBP,
-            values={
-                2024: _ONS_2024_TOTAL,
-                2025: _ONS_2024_TOTAL,
-                2026: _ONS_2024_TOTAL,
-            },
-            reference_url=_REF_URL,
-        ),
     ]

--- a/policyengine_uk_data/tests/test_land_value_targets.py
+++ b/policyengine_uk_data/tests/test_land_value_targets.py
@@ -1,7 +1,7 @@
 """Tests for ONS land value calibration targets.
 
 These validate that the generated Enhanced FRS dataset reproduces
-aggregate land and property wealth values from the ONS National
+aggregate land values from the ONS National
 Balance Sheet 2025.
 
 Source: https://www.ons.gov.uk/economy/nationalaccounts/uksectoraccounts/bulletins/nationalbalancesheet/2025
@@ -22,7 +22,6 @@ LAND_TARGETS = {
     "land_value": _ONS_2024_TOTAL,
     "household_land_value": _ONS_2020_HOUSEHOLD * _SCALE,
     "corporate_land_value": _ONS_2020_CORPORATE * _SCALE,
-    "property_wealth": _ONS_2024_TOTAL,
 }
 
 YEAR = 2025
@@ -36,7 +35,7 @@ TOLERANCE = 0.30  # 30% relative error allowed
     ids=list(LAND_TARGETS.keys()),
 )
 def test_land_value_aggregate(baseline, variable, target):
-    """Check weighted aggregate land/property values against ONS targets."""
+    """Check weighted aggregate land values against ONS targets."""
     weights = baseline.calculate("household_weight", period=YEAR).values
     values = baseline.calculate(variable, map_to="household", period=YEAR).values
     estimate = (values * weights).sum()
@@ -49,7 +48,6 @@ def test_land_value_aggregate(baseline, variable, target):
     )
 
 
-@pytest.mark.xfail(reason="Will pass after recalibration with ONS land value targets")
 def test_land_value_composition(baseline):
     """Household + corporate land should equal total land value."""
     weights = baseline.calculate("household_weight", period=YEAR).values
@@ -70,7 +68,6 @@ def test_land_value_composition(baseline):
     )
 
 
-@pytest.mark.xfail(reason="Will pass after recalibration with ONS land value targets")
 def test_household_land_less_than_property_wealth(baseline):
     """Household land value should not exceed total property wealth."""
     weights = baseline.calculate("household_weight", period=YEAR).values


### PR DESCRIPTION
## Summary

Closes #303.

This follows up on merged PR #292 by removing the incorrect `property_wealth` target from the ONS land calibration target set.

## Changes

- remove `ons/property_wealth` from `policyengine_uk_data/targets/sources/ons_land_values.py`
- stop routing `ons/property_wealth` through `compute_land_value()` in `policyengine_uk_data/targets/build_loss_matrix.py`
- keep `household_land_value <= property_wealth` as an invariant test, but not as an ONS calibration target
- make the composition and household-vs-property tests real assertions instead of `xfail`
- leave the aggregate land target test unchanged, since that still depends on rerunning calibration against rebuilt data

## Why

`property_wealth` is not an ONS land-value aggregate. Treating it as a fourth land target conflates property wealth with land value and weakens the calibration loss introduced in #292.

## Test plan

- `python3 -m compileall policyengine_uk_data/targets policyengine_uk_data/tests/test_land_value_targets.py`
- `uv run pytest policyengine_uk_data/tests/test_land_value_targets.py -q` (5 skipped in this environment)
