### PR TITLE
Publish canonical release manifests for UK data releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ documentation:
 data:
 	python policyengine_uk_data/datasets/create_datasets.py
 
+data-local:
+	@PY_PATH="$(PWD)"; \
+	if [ -d ../policyengine-uk/policyengine_uk ]; then \
+		PY_PATH="$(abspath ../policyengine-uk):$$PY_PATH"; \
+	fi; \
+	PYTHONPATH="$$PY_PATH" uv run --python 3.13 python policyengine_uk_data/datasets/create_datasets.py
+
 build:
 	python -m build
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # PolicyEngine UK Data
 
 PolicyEngine's project to build accurate UK household survey data.
+
+## Local dataset builds
+
+For a full local dataset build:
+
+1. Ensure the private prerequisite folders exist under `policyengine_uk_data/storage/`.
+2. Use Python 3.13. Python 3.14 currently fails while loading PyTables/Blosc2 in this repo.
+3. Prefer the sibling `policyengine-uk` checkout when building locally, because the published wheel in your active environment may not expose all variables required by the data pipeline.
+
+If `../policyengine-uk` exists, you can run:
+
+```sh
+make data-local
+```
  

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -1,14 +1,8 @@
-from policyengine_uk.data import UKSingleYearDataset
-from policyengine_uk_data.datasets.frs import create_frs
-from policyengine_uk_data.storage import STORAGE_FOLDER
 import logging
 import os
-from policyengine_uk_data.utils.uprating import uprate_dataset
-from policyengine_uk_data.utils.subsample import subsample_dataset
-from policyengine_uk_data.utils.progress import (
-    ProcessingProgress,
-    display_success_panel,
-    display_error_panel,
+
+from policyengine_uk_data.utils.build_environment import (
+    assert_local_build_environment,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -17,6 +11,19 @@ logging.basicConfig(level=logging.INFO)
 def main():
     """Create enhanced FRS dataset with rich progress tracking."""
     try:
+        assert_local_build_environment()
+
+        from policyengine_uk.data import UKSingleYearDataset
+        from policyengine_uk_data.datasets.frs import create_frs
+        from policyengine_uk_data.storage import STORAGE_FOLDER
+        from policyengine_uk_data.utils.progress import (
+            ProcessingProgress,
+            display_success_panel,
+            display_error_panel,
+        )
+        from policyengine_uk_data.utils.subsample import subsample_dataset
+        from policyengine_uk_data.utils.uprating import uprate_dataset
+
         # Use reduced epochs and fidelity for testing
         is_testing = os.environ.get("TESTING", "0") == "1"
         epochs = 32 if is_testing else 512
@@ -142,6 +149,7 @@ def main():
                 get_performance=get_performance,
                 nested_progress=nested_progress,  # Pass the nested progress manager
             )
+            update_dataset("Calibrate constituency weights", "completed")
 
             from policyengine_uk_data.datasets.local_areas.local_authorities.calibrate import (
                 get_performance as get_la_performance,
@@ -151,6 +159,7 @@ def main():
             )
 
             # Run calibration with verbose progress
+            update_dataset("Calibrate local authority weights", "processing")
             calibrate_local_areas(
                 dataset=frs,
                 epochs=epochs,
@@ -165,8 +174,7 @@ def main():
                 get_performance=get_la_performance,
                 nested_progress=nested_progress,  # Pass the nested progress manager
             )
-
-            update_dataset("Calibrate dataset", "completed")
+            update_dataset("Calibrate local authority weights", "completed")
 
             # Downrate and save
             update_dataset("Downrate to 2023", "processing")

--- a/policyengine_uk_data/targets/sources/slc.py
+++ b/policyengine_uk_data/targets/sources/slc.py
@@ -15,6 +15,7 @@ https://explore-education-statistics.service.gov.uk/data-tables/permalink/6ff755
 """
 
 import json
+import os
 import re
 import requests
 from functools import lru_cache
@@ -26,6 +27,23 @@ _PERMALINK_URL = (
     f"https://explore-education-statistics.service.gov.uk"
     f"/data-tables/permalink/{_PERMALINK_ID}"
 )
+_TESTING_DATA = {
+    "plan_2": {
+        2025: 3_670_000,
+        2026: 4_130_000,
+        2027: 4_480_000,
+        2028: 4_700_000,
+        2029: 4_820_000,
+        2030: 4_870_000,
+    },
+    "plan_5": {
+        2026: 25_000,
+        2027: 115_000,
+        2028: 340_000,
+        2029: 700_000,
+        2030: 1_140_000,
+    },
+}
 
 
 @lru_cache(maxsize=1)
@@ -36,6 +54,9 @@ def _fetch_slc_data() -> dict:
         Dict with keys 'plan_2' and 'plan_5', each containing a dict
         mapping calendar year (int) to borrower count above threshold (int).
     """
+    if os.environ.get("TESTING", "0") == "1":
+        return _TESTING_DATA
+
     response = requests.get(_PERMALINK_URL, timeout=30)
     response.raise_for_status()
 

--- a/policyengine_uk_data/tests/test_build_environment.py
+++ b/policyengine_uk_data/tests/test_build_environment.py
@@ -1,0 +1,31 @@
+from policyengine_uk_data.utils.build_environment import get_local_build_issues
+
+
+def test_get_local_build_issues_requires_python_313():
+    issues = get_local_build_issues(
+        python_version=(3, 14, 0),
+        variable_names={"num_vehicles"},
+    )
+
+    assert len(issues) == 1
+    assert "Python 3.13" in issues[0]
+
+
+def test_get_local_build_issues_requires_num_vehicles():
+    issues = get_local_build_issues(
+        python_version=(3, 13, 7),
+        variable_names={"salary", "household_weight"},
+    )
+
+    assert len(issues) == 1
+    assert "num_vehicles" in issues[0]
+
+
+def test_get_local_build_issues_accepts_supported_environment():
+    assert (
+        get_local_build_issues(
+            python_version=(3, 13, 7),
+            variable_names={"num_vehicles", "salary"},
+        )
+        == []
+    )

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -1,11 +1,16 @@
 import hashlib
 from io import BytesIO
+from importlib import metadata
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from huggingface_hub import CommitOperationAdd
 
-from policyengine_uk_data.utils.data_upload import upload_files_to_hf
+from policyengine_uk_data.utils.data_upload import (
+    load_release_manifest_from_hf,
+    upload_files_to_hf,
+)
 from policyengine_uk_data.utils.release_manifest import (
     RELEASE_MANIFEST_SCHEMA_VERSION,
     build_release_manifest,
@@ -117,3 +122,101 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
     for operation in release_ops:
         assert isinstance(operation, CommitOperationAdd)
         assert isinstance(operation.path_or_fileobj, BytesIO)
+
+
+def test_build_release_manifest_preserves_existing_created_at(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_frs_2023_24.h5",
+        b"enhanced-frs",
+    )
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[(dataset_path, "enhanced_frs_2023_24.h5")],
+        version="1.40.4",
+        repo_id="policyengine/policyengine-uk-data-private",
+        model_package_version="2.74.0",
+        existing_manifest={
+            "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+            "data_package": {
+                "name": "policyengine-uk-data",
+                "version": "1.40.4",
+            },
+            "compatible_model_packages": [],
+            "default_datasets": {},
+            "created_at": "2026-04-10T12:00:00Z",
+            "artifacts": {},
+        },
+        created_at="2026-04-11T08:30:00Z",
+    )
+
+    assert manifest["created_at"] == "2026-04-10T12:00:00Z"
+
+
+def test_load_release_manifest_from_hf_passes_revision(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "release_manifest.json",
+        (
+            '{"data_package": {"name": "policyengine-uk-data", "version": "1.40.4"}}'
+        ).encode()
+    )
+
+    with patch(
+        "policyengine_uk_data.utils.data_upload.hf_hub_download",
+        return_value=str(dataset_path),
+    ) as mock_download:
+        manifest = load_release_manifest_from_hf(
+            version="1.40.4",
+            revision="1.40.4",
+        )
+
+    assert manifest["data_package"]["version"] == "1.40.4"
+    assert mock_download.call_args.kwargs["revision"] == "1.40.4"
+
+
+def test_upload_files_to_hf_requires_model_package_version(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_frs_2023_24.h5",
+        b"enhanced-frs",
+    )
+
+    with (
+        patch(
+            "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_uk_data.utils.data_upload.metadata.version",
+            side_effect=metadata.PackageNotFoundError,
+        ),
+        patch.dict(
+            "policyengine_uk_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Could not determine installed version for policyengine-uk",
+        ):
+            upload_files_to_hf(files=[dataset_path], version="1.40.4")
+
+
+def test_upload_files_to_hf_rejects_finalized_release(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_frs_2023_24.h5",
+        b"enhanced-frs",
+    )
+
+    with (
+        patch(
+            "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
+            side_effect=[{"data_package": {"version": "1.40.4"}}],
+        ),
+        patch.dict(
+            "policyengine_uk_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="already finalized"):
+            upload_files_to_hf(files=[dataset_path], version="1.40.4")

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -27,9 +27,7 @@ def _sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
-EXPECTED_COMPATIBLE_MODEL_PACKAGES = [
-    {"name": "policyengine-uk", "version": "2.74.0"}
-]
+EXPECTED_COMPATIBLE_MODEL_PACKAGES = [{"name": "policyengine-uk", "version": "2.74.0"}]
 
 
 def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
@@ -70,9 +68,7 @@ def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
     assert manifest["artifacts"]["enhanced_frs_2023_24"]["sha256"] == _sha256(
         enhanced_bytes
     )
-    assert manifest["artifacts"]["frs_2023_24"]["sha256"] == _sha256(
-        baseline_bytes
-    )
+    assert manifest["artifacts"]["frs_2023_24"]["sha256"] == _sha256(baseline_bytes)
     assert manifest["artifacts"]["local_authority_weights"]["kind"] == "weights"
 
 
@@ -157,7 +153,7 @@ def test_load_release_manifest_from_hf_passes_revision(tmp_path):
         tmp_path / "release_manifest.json",
         (
             '{"data_package": {"name": "policyengine-uk-data", "version": "1.40.4"}}'
-        ).encode()
+        ).encode(),
     )
 
     with patch(

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -1,0 +1,119 @@
+import hashlib
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from huggingface_hub import CommitOperationAdd
+
+from policyengine_uk_data.utils.data_upload import upload_files_to_hf
+from policyengine_uk_data.utils.release_manifest import (
+    RELEASE_MANIFEST_SCHEMA_VERSION,
+    build_release_manifest,
+)
+
+
+def _write_file(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
+    enhanced_bytes = b"enhanced-frs"
+    baseline_bytes = b"baseline-frs"
+    weights_bytes = b"la-weights"
+
+    enhanced_path = _write_file(tmp_path / "enhanced_frs_2023_24.h5", enhanced_bytes)
+    baseline_path = _write_file(tmp_path / "frs_2023_24.h5", baseline_bytes)
+    weights_path = _write_file(
+        tmp_path / "local_authority_weights.h5",
+        weights_bytes,
+    )
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[
+            (enhanced_path, "enhanced_frs_2023_24.h5"),
+            (baseline_path, "frs_2023_24.h5"),
+            (weights_path, "local_authority_weights.h5"),
+        ],
+        version="1.40.4",
+        repo_id="policyengine/policyengine-uk-data-private",
+        model_package_version="2.74.0",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    assert manifest["data_package"] == {
+        "name": "policyengine-uk-data",
+        "version": "1.40.4",
+    }
+    assert manifest["schema_version"] == RELEASE_MANIFEST_SCHEMA_VERSION
+    assert manifest["compatible_model_packages"] == [
+        {
+            "name": "policyengine-uk",
+            "specifier": "==2.74.0",
+        }
+    ]
+    assert manifest["default_datasets"] == {
+        "national": "enhanced_frs_2023_24",
+        "baseline": "frs_2023_24",
+    }
+
+    assert manifest["artifacts"]["enhanced_frs_2023_24"]["sha256"] == _sha256(
+        enhanced_bytes
+    )
+    assert manifest["artifacts"]["frs_2023_24"]["sha256"] == _sha256(
+        baseline_bytes
+    )
+    assert manifest["artifacts"]["local_authority_weights"]["kind"] == "weights"
+
+
+def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_frs_2023_24.h5",
+        b"enhanced-frs",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="commit-sha")
+
+    with (
+        patch("policyengine_uk_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_uk_data.utils.data_upload.metadata.version",
+            return_value="2.74.0",
+        ),
+        patch.dict(
+            "policyengine_uk_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        upload_files_to_hf(
+            files=[dataset_path],
+            version="1.40.4",
+        )
+
+    operations = mock_api.create_commit.call_args.kwargs["operations"]
+    operation_paths = [operation.path_in_repo for operation in operations]
+
+    assert "enhanced_frs_2023_24.h5" in operation_paths
+    assert "release_manifest.json" in operation_paths
+    assert "releases/1.40.4/release_manifest.json" in operation_paths
+
+    release_ops = [
+        operation
+        for operation in operations
+        if operation.path_in_repo.endswith("release_manifest.json")
+    ]
+    assert len(release_ops) == 2
+    for operation in release_ops:
+        assert isinstance(operation, CommitOperationAdd)
+        assert isinstance(operation.path_or_fileobj, BytesIO)

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -27,6 +27,11 @@ def _sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+EXPECTED_COMPATIBLE_MODEL_PACKAGES = [
+    {"name": "policyengine-uk", "version": "2.74.0"}
+]
+
+
 def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
     enhanced_bytes = b"enhanced-frs"
     baseline_bytes = b"baseline-frs"
@@ -56,12 +61,7 @@ def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
         "version": "1.40.4",
     }
     assert manifest["schema_version"] == RELEASE_MANIFEST_SCHEMA_VERSION
-    assert manifest["compatible_model_packages"] == [
-        {
-            "name": "policyengine-uk",
-            "specifier": "==2.74.0",
-        }
-    ]
+    assert manifest["compatible_model_packages"] == EXPECTED_COMPATIBLE_MODEL_PACKAGES
     assert manifest["default_datasets"] == {
         "national": "enhanced_frs_2023_24",
         "baseline": "frs_2023_24",
@@ -141,7 +141,7 @@ def test_build_release_manifest_preserves_existing_created_at(tmp_path):
                 "name": "policyengine-uk-data",
                 "version": "1.40.4",
             },
-            "compatible_model_packages": [],
+            "compatible_model_packages": EXPECTED_COMPATIBLE_MODEL_PACKAGES,
             "default_datasets": {},
             "created_at": "2026-04-10T12:00:00Z",
             "artifacts": {},

--- a/policyengine_uk_data/tests/test_student_loan_targets.py
+++ b/policyengine_uk_data/tests/test_student_loan_targets.py
@@ -1,7 +1,5 @@
 """Tests for SLC student loan calibration targets."""
 
-import pytest
-
 
 def test_slc_targets_registered():
     """SLC targets appear in the target registry."""
@@ -32,3 +30,20 @@ def test_slc_plan5_values():
     assert 2025 not in p5.values  # no Plan 5 borrowers yet in 2024-25
     assert p5.values[2026] == 25_000
     assert p5.values[2029] == 700_000
+
+
+def test_slc_testing_mode_uses_snapshot_without_network(monkeypatch):
+    """Dataset-build CI should not depend on a live SLC endpoint."""
+    from policyengine_uk_data.targets.sources import slc
+
+    slc._fetch_slc_data.cache_clear()
+    monkeypatch.setenv("TESTING", "1")
+
+    def fail_network(*args, **kwargs):
+        raise AssertionError("network should not be used in TESTING mode")
+
+    monkeypatch.setattr(slc.requests, "get", fail_network)
+
+    assert slc._fetch_slc_data() == slc._TESTING_DATA
+
+    slc._fetch_slc_data.cache_clear()

--- a/policyengine_uk_data/utils/build_environment.py
+++ b/policyengine_uk_data/utils/build_environment.py
@@ -39,6 +39,5 @@ def assert_local_build_environment() -> None:
         return
 
     raise RuntimeError(
-        "Local UK data build environment is not compatible:\n- "
-        + "\n- ".join(issues)
+        "Local UK data build environment is not compatible:\n- " + "\n- ".join(issues)
     )

--- a/policyengine_uk_data/utils/build_environment.py
+++ b/policyengine_uk_data/utils/build_environment.py
@@ -1,0 +1,44 @@
+import sys
+from typing import Iterable
+
+
+def get_local_build_issues(
+    python_version: tuple[int, ...] | None = None,
+    variable_names: Iterable[str] | None = None,
+) -> list[str]:
+    issues: list[str] = []
+
+    if python_version is None:
+        python_version = sys.version_info[:3]
+
+    if tuple(python_version)[:2] != (3, 13):
+        issues.append(
+            "Use Python 3.13 for local dataset builds. Python 3.14 currently "
+            "fails while loading PyTables/Blosc2 in this repo."
+        )
+
+    if variable_names is None:
+        from policyengine_uk import CountryTaxBenefitSystem
+
+        variable_names = CountryTaxBenefitSystem().variables
+
+    if "num_vehicles" not in set(variable_names):
+        issues.append(
+            "The resolved policyengine-uk package does not expose the "
+            "`num_vehicles` variable required by the UK data pipeline. For "
+            "local builds, prefer the sibling `policyengine-uk` checkout on "
+            "PYTHONPATH."
+        )
+
+    return issues
+
+
+def assert_local_build_environment() -> None:
+    issues = get_local_build_issues()
+    if not issues:
+        return
+
+    raise RuntimeError(
+        "Local UK data build environment is not compatible:\n- "
+        + "\n- ".join(issues)
+    )

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -86,6 +86,20 @@ def assert_release_not_finalized(
         )
 
 
+def get_repo_head_revision(
+    api: HfApi,
+    repo_id: str,
+    repo_type: str,
+    token: Optional[str] = None,
+) -> Optional[str]:
+    repo_info = api.repo_info(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        token=token,
+    )
+    return getattr(repo_info, "sha", None)
+
+
 def create_release_manifest_commit_operations(
     files_with_repo_paths: List[Tuple[Path, str]],
     version: str,
@@ -124,14 +138,14 @@ def create_release_manifest_commit_operations(
 def upload_data_files(
     files: List[str],
     gcs_bucket_name: str = "policyengine-uk-data-private",
-    hf_repo_name: str = "policyengine/policyengine-uk-data",
+    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
     hf_repo_type: str = "model",
     version: str = None,
 ):
     if version is None:
         version = metadata.version("policyengine-uk-data")
 
-    upload_files_to_hf(
+    commit_oid = upload_files_to_hf(
         files=files,
         version=version,
         hf_repo_name=hf_repo_name,
@@ -142,6 +156,13 @@ def upload_data_files(
         files=files,
         version=version,
         gcs_bucket_name=gcs_bucket_name,
+    )
+
+    create_release_tag(
+        version=version,
+        revision=commit_oid,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
     )
 
 
@@ -179,16 +200,23 @@ def upload_files_to_hf(
             )
         )
 
+    model_package_version = _get_model_package_version()
     existing_manifest = load_release_manifest_from_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
+    parent_commit = get_repo_head_revision(
+        api=api,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+    )
     _, manifest_operations = create_release_manifest_commit_operations(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
         hf_repo_name=hf_repo_name,
-        model_package_version=_get_model_package_version(),
+        model_package_version=model_package_version,
         existing_manifest=existing_manifest,
     )
     hf_operations.extend(manifest_operations)
@@ -199,26 +227,58 @@ def upload_files_to_hf(
         operations=hf_operations,
         repo_type=hf_repo_type,
         commit_message=f"Upload data files for version {version}",
+        parent_commit=parent_commit,
     )
     logging.info(f"Uploaded files to Hugging Face repository {hf_repo_name}.")
+    return commit_info.oid
 
-    # Tag commit with version
+
+def create_release_tag(
+    version: str,
+    revision: str,
+    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
+    hf_repo_type: str = "model",
+    token: Optional[str] = None,
+    api: Optional[HfApi] = None,
+) -> None:
+    api = api or HfApi()
+    token = token or os.environ.get("HUGGING_FACE_TOKEN")
     try:
         api.create_tag(
             token=token,
             repo_id=hf_repo_name,
             tag=version,
-            revision=commit_info.oid,
+            revision=revision,
             repo_type=hf_repo_type,
+            exist_ok=False,
         )
         logging.info(
             f"Tagged commit with {version} in Hugging Face repository {hf_repo_name}."
         )
     except Exception as e:
         if "Tag reference exists already" in str(e) or "409" in str(e):
-            logging.warning(
-                f"Tag {version} already exists in {hf_repo_name}. Skipping tag creation."
+            tagged_revision = getattr(
+                api.repo_info(
+                    repo_id=hf_repo_name,
+                    repo_type=hf_repo_type,
+                    revision=version,
+                    token=token,
+                ),
+                "sha",
+                None,
             )
+            if tagged_revision == revision:
+                logging.info(
+                    "Tag %s already exists in %s and already points to %s.",
+                    version,
+                    hf_repo_name,
+                    revision,
+                )
+                return
+            raise RuntimeError(
+                f"Tag {version} already exists in {hf_repo_name} at "
+                f"{tagged_revision}; refusing to treat {revision} as finalized."
+            ) from e
         else:
             raise
 

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -1,12 +1,98 @@
-from typing import List
-from huggingface_hub import HfApi, CommitOperationAdd
+from io import BytesIO
+from typing import Dict, List, Optional, Tuple
+from huggingface_hub import HfApi, CommitOperationAdd, hf_hub_download
 from huggingface_hub.errors import RevisionNotFoundError
 from google.cloud import storage
 from pathlib import Path
 from importlib import metadata
 import google.auth
+import json
 import logging
 import os
+
+from policyengine_uk_data.utils.release_manifest import (
+    build_release_manifest,
+    serialize_release_manifest,
+)
+
+RELEASE_MANIFEST_PATH = "release_manifest.json"
+
+
+def _get_model_package_version(
+    package_name: str = "policyengine-uk",
+) -> Optional[str]:
+    try:
+        return metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        logging.warning(
+            "Could not determine installed version for %s while building release manifest.",
+            package_name,
+        )
+        return None
+
+
+def load_release_manifest_from_hf(
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
+    hf_repo_type: str = "model",
+) -> Optional[Dict]:
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    candidate_paths = [
+        f"releases/{version}/{RELEASE_MANIFEST_PATH}",
+        RELEASE_MANIFEST_PATH,
+    ]
+
+    for path_in_repo in candidate_paths:
+        try:
+            manifest_path = hf_hub_download(
+                repo_id=hf_repo_name,
+                filename=path_in_repo,
+                repo_type=hf_repo_type,
+                token=token,
+            )
+        except RevisionNotFoundError:
+            raise
+        except Exception:
+            continue
+
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+
+        data_package = manifest.get("data_package", {})
+        if data_package.get("version") == version:
+            return manifest
+
+    return None
+
+
+def create_release_manifest_commit_operations(
+    files_with_repo_paths: List[Tuple[Path, str]],
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
+    model_package_name: str = "policyengine-uk",
+    model_package_version: Optional[str] = None,
+    existing_manifest: Optional[Dict] = None,
+) -> Tuple[Dict, List[CommitOperationAdd]]:
+    manifest = build_release_manifest(
+        files_with_repo_paths=files_with_repo_paths,
+        version=version,
+        repo_id=hf_repo_name,
+        model_package_name=model_package_name,
+        model_package_version=model_package_version,
+        existing_manifest=existing_manifest,
+    )
+    manifest_payload = serialize_release_manifest(manifest)
+    operations = [
+        CommitOperationAdd(
+            path_in_repo=RELEASE_MANIFEST_PATH,
+            path_or_fileobj=BytesIO(manifest_payload),
+        ),
+        CommitOperationAdd(
+            path_in_repo=f"releases/{version}/{RELEASE_MANIFEST_PATH}",
+            path_or_fileobj=BytesIO(manifest_payload),
+        ),
+    ]
+    return manifest, operations
 
 
 def upload_data_files(
@@ -47,17 +133,35 @@ def upload_files_to_hf(
         "HUGGING_FACE_TOKEN",
     )
     hf_operations = []
+    files_with_repo_paths = []
 
     for file_path in files:
         file_path = Path(file_path)
         if not file_path.exists():
             raise ValueError(f"File {file_path} does not exist.")
+        repo_path = file_path.name
+        files_with_repo_paths.append((file_path, repo_path))
         hf_operations.append(
             CommitOperationAdd(
-                path_in_repo=file_path.name,
+                path_in_repo=repo_path,
                 path_or_fileobj=str(file_path),
             )
         )
+
+    existing_manifest = load_release_manifest_from_hf(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    _, manifest_operations = create_release_manifest_commit_operations(
+        files_with_repo_paths=files_with_repo_paths,
+        version=version,
+        hf_repo_name=hf_repo_name,
+        model_package_version=_get_model_package_version(),
+        existing_manifest=existing_manifest,
+    )
+    hf_operations.extend(manifest_operations)
+
     commit_info = api.create_commit(
         token=token,
         repo_id=hf_repo_name,
@@ -68,16 +172,24 @@ def upload_files_to_hf(
     logging.info(f"Uploaded files to Hugging Face repository {hf_repo_name}.")
 
     # Tag commit with version
-    api.create_tag(
-        token=token,
-        repo_id=hf_repo_name,
-        tag=version,
-        revision=commit_info.oid,
-        repo_type=hf_repo_type,
-    )
-    logging.info(
-        f"Tagged commit with {version} in Hugging Face repository {hf_repo_name}."
-    )
+    try:
+        api.create_tag(
+            token=token,
+            repo_id=hf_repo_name,
+            tag=version,
+            revision=commit_info.oid,
+            repo_type=hf_repo_type,
+        )
+        logging.info(
+            f"Tagged commit with {version} in Hugging Face repository {hf_repo_name}."
+        )
+    except Exception as e:
+        if "Tag reference exists already" in str(e) or "409" in str(e):
+            logging.warning(
+                f"Tag {version} already exists in {hf_repo_name}. Skipping tag creation."
+            )
+        else:
+            raise
 
 
 def upload_files_to_gcs(

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -20,21 +20,21 @@ RELEASE_MANIFEST_PATH = "release_manifest.json"
 
 def _get_model_package_version(
     package_name: str = "policyengine-uk",
-) -> Optional[str]:
+) -> str:
     try:
         return metadata.version(package_name)
     except metadata.PackageNotFoundError:
-        logging.warning(
-            "Could not determine installed version for %s while building release manifest.",
-            package_name,
+        raise RuntimeError(
+            "Could not determine installed version for "
+            f"{package_name} while building a release manifest."
         )
-        return None
 
 
 def load_release_manifest_from_hf(
     version: str,
     hf_repo_name: str = "policyengine/policyengine-uk-data-private",
     hf_repo_type: str = "model",
+    revision: Optional[str] = None,
 ) -> Optional[Dict]:
     token = os.environ.get("HUGGING_FACE_TOKEN")
     candidate_paths = [
@@ -49,9 +49,10 @@ def load_release_manifest_from_hf(
                 filename=path_in_repo,
                 repo_type=hf_repo_type,
                 token=token,
+                revision=revision,
             )
         except RevisionNotFoundError:
-            raise
+            return None
         except Exception:
             continue
 
@@ -65,6 +66,26 @@ def load_release_manifest_from_hf(
     return None
 
 
+def assert_release_not_finalized(
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
+    hf_repo_type: str = "model",
+) -> None:
+    if (
+        load_release_manifest_from_hf(
+            version=version,
+            hf_repo_name=hf_repo_name,
+            hf_repo_type=hf_repo_type,
+            revision=version,
+        )
+        is not None
+    ):
+        raise RuntimeError(
+            f"Release {version} is already finalized on {hf_repo_name}. "
+            "Refusing to mutate release manifest state after the tag exists."
+        )
+
+
 def create_release_manifest_commit_operations(
     files_with_repo_paths: List[Tuple[Path, str]],
     version: str,
@@ -73,6 +94,11 @@ def create_release_manifest_commit_operations(
     model_package_version: Optional[str] = None,
     existing_manifest: Optional[Dict] = None,
 ) -> Tuple[Dict, List[CommitOperationAdd]]:
+    if not model_package_version:
+        raise RuntimeError(
+            "A compatible policyengine-uk version is required when publishing "
+            "a release manifest."
+        )
     manifest = build_release_manifest(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
@@ -131,6 +157,11 @@ def upload_files_to_hf(
     api = HfApi()
     token = os.environ.get(
         "HUGGING_FACE_TOKEN",
+    )
+    assert_release_not_finalized(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
     )
     hf_operations = []
     files_with_repo_paths = []

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -42,8 +42,7 @@ def _base_manifest(
     *,
     version: str,
     data_package_name: str,
-    model_package_name: str,
-    model_package_version: str | None,
+    compatible_model_packages: Sequence[Dict[str, str]],
     created_at: str,
 ) -> Dict:
     manifest = {
@@ -52,19 +51,21 @@ def _base_manifest(
             "name": data_package_name,
             "version": version,
         },
-        "compatible_model_packages": [],
+        "compatible_model_packages": list(compatible_model_packages),
         "default_datasets": {},
         "created_at": created_at,
         "artifacts": {},
     }
-    if model_package_version:
-        manifest["compatible_model_packages"].append(
-            {
-                "name": model_package_name,
-                "specifier": f"=={model_package_version}",
-            }
-        )
     return manifest
+
+
+def _compatible_model_packages(
+    model_package_name: str,
+    model_package_version: str | None,
+) -> list[Dict[str, str]]:
+    if not model_package_version:
+        return []
+    return [{"name": model_package_name, "version": model_package_version}]
 
 
 def _normalize_existing_manifest(
@@ -107,20 +108,19 @@ def build_release_manifest(
         manifest = _base_manifest(
             version=version,
             data_package_name=data_package_name,
-            model_package_name=model_package_name,
-            model_package_version=model_package_version,
+            compatible_model_packages=_compatible_model_packages(
+                model_package_name,
+                model_package_version,
+            ),
             created_at=manifest_timestamp,
         )
     else:
         manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
         manifest["created_at"] = manifest.get("created_at") or manifest_timestamp
-        if model_package_version:
-            manifest["compatible_model_packages"] = [
-                {
-                    "name": model_package_name,
-                    "specifier": f"=={model_package_version}",
-                }
-            ]
+        manifest["compatible_model_packages"] = _compatible_model_packages(
+            model_package_name,
+            model_package_version,
+        )
 
     if default_datasets:
         manifest.setdefault("default_datasets", {}).update(default_datasets)

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -77,10 +77,7 @@ def _normalize_existing_manifest(
     if existing_manifest is None:
         return None
     package = existing_manifest.get("data_package", {})
-    if (
-        package.get("name") != data_package_name
-        or package.get("version") != version
-    ):
+    if package.get("name") != data_package_name or package.get("version") != version:
         return None
     return deepcopy(dict(existing_manifest))
 

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -113,7 +113,7 @@ def build_release_manifest(
         )
     else:
         manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
-        manifest["created_at"] = manifest_timestamp
+        manifest["created_at"] = manifest.get("created_at") or manifest_timestamp
         if model_package_version:
             manifest["compatible_model_packages"] = [
                 {

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+from typing import Dict, Mapping, Optional, Sequence, Tuple
+
+RELEASE_MANIFEST_SCHEMA_VERSION = 1
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _compute_file_checksum(file_path: Path) -> str:
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def _artifact_key(path_in_repo: str) -> str:
+    return str(PurePosixPath(path_in_repo).with_suffix(""))
+
+
+def _artifact_kind(path_in_repo: str) -> str:
+    path = PurePosixPath(path_in_repo)
+    suffix = path.suffix.lower()
+    if suffix == ".h5":
+        if "weight" in path.stem:
+            return "weights"
+        return "microdata"
+    if suffix == ".db":
+        return "database"
+    return "auxiliary"
+
+
+def _base_manifest(
+    *,
+    version: str,
+    data_package_name: str,
+    model_package_name: str,
+    model_package_version: str | None,
+    created_at: str,
+) -> Dict:
+    manifest = {
+        "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "data_package": {
+            "name": data_package_name,
+            "version": version,
+        },
+        "compatible_model_packages": [],
+        "default_datasets": {},
+        "created_at": created_at,
+        "artifacts": {},
+    }
+    if model_package_version:
+        manifest["compatible_model_packages"].append(
+            {
+                "name": model_package_name,
+                "specifier": f"=={model_package_version}",
+            }
+        )
+    return manifest
+
+
+def _normalize_existing_manifest(
+    existing_manifest: Mapping | None,
+    *,
+    version: str,
+    data_package_name: str,
+) -> Dict | None:
+    if existing_manifest is None:
+        return None
+    package = existing_manifest.get("data_package", {})
+    if (
+        package.get("name") != data_package_name
+        or package.get("version") != version
+    ):
+        return None
+    return deepcopy(dict(existing_manifest))
+
+
+def build_release_manifest(
+    *,
+    files_with_repo_paths: Sequence[Tuple[Path | str, str]],
+    version: str,
+    repo_id: str,
+    data_package_name: str = "policyengine-uk-data",
+    model_package_name: str = "policyengine-uk",
+    model_package_version: str | None = None,
+    existing_manifest: Mapping | None = None,
+    default_datasets: Optional[Mapping[str, str]] = None,
+    created_at: str | None = None,
+) -> Dict:
+    manifest = _normalize_existing_manifest(
+        existing_manifest,
+        version=version,
+        data_package_name=data_package_name,
+    )
+    manifest_timestamp = created_at or _utc_timestamp()
+
+    if manifest is None:
+        manifest = _base_manifest(
+            version=version,
+            data_package_name=data_package_name,
+            model_package_name=model_package_name,
+            model_package_version=model_package_version,
+            created_at=manifest_timestamp,
+        )
+    else:
+        manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
+        manifest["created_at"] = manifest_timestamp
+        if model_package_version:
+            manifest["compatible_model_packages"] = [
+                {
+                    "name": model_package_name,
+                    "specifier": f"=={model_package_version}",
+                }
+            ]
+
+    if default_datasets:
+        manifest.setdefault("default_datasets", {}).update(default_datasets)
+
+    for local_path, path_in_repo in files_with_repo_paths:
+        local_path = Path(local_path)
+        manifest["artifacts"][_artifact_key(path_in_repo)] = {
+            "kind": _artifact_kind(path_in_repo),
+            "path": path_in_repo,
+            "repo_id": repo_id,
+            "revision": version,
+            "sha256": _compute_file_checksum(local_path),
+            "size_bytes": local_path.stat().st_size,
+        }
+
+    defaults = manifest["default_datasets"]
+    if "national" not in defaults and "enhanced_frs_2023_24" in manifest["artifacts"]:
+        defaults["national"] = "enhanced_frs_2023_24"
+    if "baseline" not in defaults and "frs_2023_24" in manifest["artifacts"]:
+        defaults["baseline"] = "frs_2023_24"
+
+    return manifest
+
+
+def serialize_release_manifest(manifest: Mapping) -> bytes:
+    return (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")


### PR DESCRIPTION
## Summary
- add a canonical release manifest for UK data artifacts
- publish the manifest through the existing upload path
- add focused tests for release-manifest generation

Refs #322.