### PR TITLE
Add ESA and JSA calibration targets

### DIFF
--- a/policyengine_uk_data/targets/sources/dwp.py
+++ b/policyengine_uk_data/targets/sources/dwp.py
@@ -1,16 +1,25 @@
 """DWP benefit targets.
 
-PIP daily living standard/enhanced claimant counts, benefit cap,
-UC payment distribution, UC claimant counts by children/family type,
-two-child limit breakdowns, and Scotland UC households with child under 1.
+PIP daily living standard/enhanced claimant counts, ESA/JSA claimant
+counts, benefit cap, UC payment distribution, UC claimant counts by
+children/family type, two-child limit breakdowns, and Scotland UC
+households with child under 1.
 
 Sources:
+- DWP benefit statistics: https://www.gov.uk/government/statistics/dwp-benefit-statistics-february-2026/dwp-benefit-statistics-february-2026
 - DWP Stat-Xplore: https://stat-xplore.dwp.gov.uk
 - DWP benefit cap: https://www.gov.uk/government/statistics/benefit-cap-number-of-households-capped-to-february-2025
 - DWP two-child limit: https://www.gov.uk/government/statistics/universal-credit-and-child-tax-credit-claimants-statistics-related-to-the-policy-to-provide-support-for-a-maximum-of-2-children-april-2024
 """
 
 from policyengine_uk_data.targets.schema import Target, Unit
+
+
+_DWP_BENEFIT_STATS_FEB_2026 = (
+    "https://www.gov.uk/government/statistics/"
+    "dwp-benefit-statistics-february-2026/"
+    "dwp-benefit-statistics-february-2026"
+)
 
 
 def get_targets() -> list[Target]:
@@ -39,6 +48,52 @@ def get_targets() -> list[Target]:
             is_count=True,
             reference_url="https://www.disabilityrightsuk.org/news/90-pip-standard-daily-living-component-recipients-would-fail-new-green-paper-test",
         )
+    )
+
+    # ESA and JSA claimant counts from the DWP summary release.
+    #
+    # The JSA scheme is now effectively New Style / contributory only,
+    # so the official JSA claimant count is mapped to jsa_contrib rather
+    # than the legacy jsa_income variable.
+    targets.extend(
+        [
+            Target(
+                name="dwp/esa_claimants",
+                variable="esa",
+                source="dwp",
+                unit=Unit.COUNT,
+                values={2025: 999_000},
+                is_count=True,
+                reference_url=_DWP_BENEFIT_STATS_FEB_2026,
+            ),
+            Target(
+                name="dwp/esa_contrib_claimants",
+                variable="esa_contrib",
+                source="dwp",
+                unit=Unit.COUNT,
+                values={2025: 620_000},
+                is_count=True,
+                reference_url=_DWP_BENEFIT_STATS_FEB_2026,
+            ),
+            Target(
+                name="dwp/esa_income_claimants",
+                variable="esa_income",
+                source="dwp",
+                unit=Unit.COUNT,
+                values={2025: 180_000},
+                is_count=True,
+                reference_url=_DWP_BENEFIT_STATS_FEB_2026,
+            ),
+            Target(
+                name="dwp/jsa_claimants",
+                variable="jsa_contrib",
+                source="dwp",
+                unit=Unit.COUNT,
+                values={2025: 71_000},
+                is_count=True,
+                reference_url=_DWP_BENEFIT_STATS_FEB_2026,
+            ),
+        ]
     )
 
     # Benefit cap

--- a/policyengine_uk_data/targets/sources/obr.py
+++ b/policyengine_uk_data/targets/sources/obr.py
@@ -319,7 +319,7 @@ def _parse_welfare(wb: openpyxl.Workbook) -> list[Target]:
         "state_pension": ("State pension", "state_pension"),
         "jobseekers_allowance": (
             "Jobseeker's allowance",
-            "jsa_income",
+            "jsa",
         ),
     }
 

--- a/policyengine_uk_data/tests/test_esa_jsa_targets.py
+++ b/policyengine_uk_data/tests/test_esa_jsa_targets.py
@@ -1,0 +1,40 @@
+"""Tests for ESA/JSA calibration target definitions."""
+
+import openpyxl
+
+from policyengine_uk_data.targets.sources import dwp, obr
+
+
+def test_dwp_esa_jsa_claimant_targets_exist():
+    targets = {target.name: target for target in dwp.get_targets()}
+
+    assert targets["dwp/esa_claimants"].variable == "esa"
+    assert targets["dwp/esa_claimants"].values[2025] == 999_000
+
+    assert targets["dwp/esa_contrib_claimants"].variable == "esa_contrib"
+    assert targets["dwp/esa_contrib_claimants"].values[2025] == 620_000
+
+    assert targets["dwp/esa_income_claimants"].variable == "esa_income"
+    assert targets["dwp/esa_income_claimants"].values[2025] == 180_000
+
+    # The official 2025 JSA caseload is New Style / contributory JSA.
+    assert targets["dwp/jsa_claimants"].variable == "jsa_contrib"
+    assert targets["dwp/jsa_claimants"].values[2025] == 71_000
+
+
+def test_obr_jobseekers_allowance_maps_to_total_jsa():
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "4.9"
+    ws["B2"] = "Jobseeker's allowance"
+    ws["C2"] = 0.2
+    ws["D2"] = 0.3
+    ws["E2"] = 0.2
+    ws["F2"] = 0.2
+    ws["G2"] = 0.3
+    ws["H2"] = 0.2
+    ws["I2"] = 0.2
+
+    targets = {target.name: target for target in obr._parse_welfare(wb)}
+
+    assert targets["obr/jobseekers_allowance"].variable == "jsa"


### PR DESCRIPTION
## Summary
- add DWP claimant-count targets for ESA total, ESA contributory, ESA income-related, and current JSA claims
- fix the OBR Jobseeker's Allowance target to map to total `jsa` rather than only `jsa_income`
- add focused tests for the new DWP targets and the OBR JSA mapping

## Why
The current calibration target set barely constrains ESA/JSA. ESA only has a coarse OBR spending anchor, and JSA spending was incorrectly matched to `jsa_income` only. That made the ESA/JSA asset-rule integration unstable under recalibration.

## Verification
- `uv run pytest -q policyengine_uk_data/tests/test_esa_jsa_targets.py`
- `uv run pytest -q policyengine_uk_data/tests/test_target_registry.py`
- `uvx ruff check policyengine_uk_data/targets/sources/dwp.py policyengine_uk_data/targets/sources/obr.py policyengine_uk_data/tests/test_esa_jsa_targets.py`