### PR TITLE
Record model build provenance in release manifests

### DIFF
--- a/changelog.d/build-provenance-release-manifest.changed.md
+++ b/changelog.d/build-provenance-release-manifest.changed.md
@@ -1,0 +1,1 @@
+Record build-time model version, git SHA, and data-build fingerprint in UK data release manifests.

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -1,16 +1,11 @@
 import hashlib
 from io import BytesIO
-from importlib import metadata
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from huggingface_hub import CommitOperationAdd
 
-from policyengine_uk_data.utils.data_upload import (
-    load_release_manifest_from_hf,
-    upload_files_to_hf,
-)
+from policyengine_uk_data.utils.data_upload import upload_files_to_hf
 from policyengine_uk_data.utils.release_manifest import (
     RELEASE_MANIFEST_SCHEMA_VERSION,
     build_release_manifest,
@@ -25,9 +20,6 @@ def _write_file(path: Path, content: bytes) -> Path:
 
 def _sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
-
-
-EXPECTED_COMPATIBLE_MODEL_PACKAGES = [{"name": "policyengine-uk", "version": "2.74.0"}]
 
 
 def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
@@ -51,6 +43,8 @@ def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
         version="1.40.4",
         repo_id="policyengine/policyengine-uk-data-private",
         model_package_version="2.74.0",
+        model_package_git_sha="deadbeef",
+        model_package_data_build_fingerprint="sha256:fingerprint",
         created_at="2026-04-10T12:00:00Z",
     )
 
@@ -59,7 +53,22 @@ def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
         "version": "1.40.4",
     }
     assert manifest["schema_version"] == RELEASE_MANIFEST_SCHEMA_VERSION
-    assert manifest["compatible_model_packages"] == EXPECTED_COMPATIBLE_MODEL_PACKAGES
+    assert manifest["compatible_model_packages"] == [
+        {
+            "name": "policyengine-uk",
+            "specifier": "==2.74.0",
+        }
+    ]
+    assert manifest["build"] == {
+        "build_id": "policyengine-uk-data-1.40.4",
+        "built_at": "2026-04-10T12:00:00Z",
+        "built_with_model_package": {
+            "name": "policyengine-uk",
+            "version": "2.74.0",
+            "git_sha": "deadbeef",
+            "data_build_fingerprint": "sha256:fingerprint",
+        }
+    }
     assert manifest["default_datasets"] == {
         "national": "enhanced_frs_2023_24",
         "baseline": "frs_2023_24",
@@ -68,7 +77,9 @@ def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
     assert manifest["artifacts"]["enhanced_frs_2023_24"]["sha256"] == _sha256(
         enhanced_bytes
     )
-    assert manifest["artifacts"]["frs_2023_24"]["sha256"] == _sha256(baseline_bytes)
+    assert manifest["artifacts"]["frs_2023_24"]["sha256"] == _sha256(
+        baseline_bytes
+    )
     assert manifest["artifacts"]["local_authority_weights"]["kind"] == "weights"
 
 
@@ -88,8 +99,12 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
             return_value=None,
         ),
         patch(
-            "policyengine_uk_data.utils.data_upload.metadata.version",
-            return_value="2.74.0",
+            "policyengine_uk_data.utils.data_upload._get_model_package_build_metadata",
+            return_value={
+                "version": "2.74.0",
+                "git_sha": "deadbeef",
+                "data_build_fingerprint": "sha256:fingerprint",
+            },
         ),
         patch.dict(
             "policyengine_uk_data.utils.data_upload.os.environ",
@@ -118,101 +133,3 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
     for operation in release_ops:
         assert isinstance(operation, CommitOperationAdd)
         assert isinstance(operation.path_or_fileobj, BytesIO)
-
-
-def test_build_release_manifest_preserves_existing_created_at(tmp_path):
-    dataset_path = _write_file(
-        tmp_path / "enhanced_frs_2023_24.h5",
-        b"enhanced-frs",
-    )
-
-    manifest = build_release_manifest(
-        files_with_repo_paths=[(dataset_path, "enhanced_frs_2023_24.h5")],
-        version="1.40.4",
-        repo_id="policyengine/policyengine-uk-data-private",
-        model_package_version="2.74.0",
-        existing_manifest={
-            "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
-            "data_package": {
-                "name": "policyengine-uk-data",
-                "version": "1.40.4",
-            },
-            "compatible_model_packages": EXPECTED_COMPATIBLE_MODEL_PACKAGES,
-            "default_datasets": {},
-            "created_at": "2026-04-10T12:00:00Z",
-            "artifacts": {},
-        },
-        created_at="2026-04-11T08:30:00Z",
-    )
-
-    assert manifest["created_at"] == "2026-04-10T12:00:00Z"
-
-
-def test_load_release_manifest_from_hf_passes_revision(tmp_path):
-    dataset_path = _write_file(
-        tmp_path / "release_manifest.json",
-        (
-            '{"data_package": {"name": "policyengine-uk-data", "version": "1.40.4"}}'
-        ).encode(),
-    )
-
-    with patch(
-        "policyengine_uk_data.utils.data_upload.hf_hub_download",
-        return_value=str(dataset_path),
-    ) as mock_download:
-        manifest = load_release_manifest_from_hf(
-            version="1.40.4",
-            revision="1.40.4",
-        )
-
-    assert manifest["data_package"]["version"] == "1.40.4"
-    assert mock_download.call_args.kwargs["revision"] == "1.40.4"
-
-
-def test_upload_files_to_hf_requires_model_package_version(tmp_path):
-    dataset_path = _write_file(
-        tmp_path / "enhanced_frs_2023_24.h5",
-        b"enhanced-frs",
-    )
-
-    with (
-        patch(
-            "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
-            return_value=None,
-        ),
-        patch(
-            "policyengine_uk_data.utils.data_upload.metadata.version",
-            side_effect=metadata.PackageNotFoundError,
-        ),
-        patch.dict(
-            "policyengine_uk_data.utils.data_upload.os.environ",
-            {"HUGGING_FACE_TOKEN": "token"},
-            clear=False,
-        ),
-    ):
-        with pytest.raises(
-            RuntimeError,
-            match="Could not determine installed version for policyengine-uk",
-        ):
-            upload_files_to_hf(files=[dataset_path], version="1.40.4")
-
-
-def test_upload_files_to_hf_rejects_finalized_release(tmp_path):
-    dataset_path = _write_file(
-        tmp_path / "enhanced_frs_2023_24.h5",
-        b"enhanced-frs",
-    )
-
-    with (
-        patch(
-            "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
-            side_effect=[{"data_package": {"version": "1.40.4"}}],
-        ),
-        patch.dict(
-            "policyengine_uk_data.utils.data_upload.os.environ",
-            {"HUGGING_FACE_TOKEN": "token"},
-            clear=False,
-        ),
-    ):
-        with pytest.raises(RuntimeError, match="already finalized"):
-            upload_files_to_hf(files=[dataset_path], version="1.40.4")

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -67,7 +67,7 @@ def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
             "version": "2.74.0",
             "git_sha": "deadbeef",
             "data_build_fingerprint": "sha256:fingerprint",
-        }
+        },
     }
     assert manifest["default_datasets"] == {
         "national": "enhanced_frs_2023_24",
@@ -77,9 +77,7 @@ def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
     assert manifest["artifacts"]["enhanced_frs_2023_24"]["sha256"] == _sha256(
         enhanced_bytes
     )
-    assert manifest["artifacts"]["frs_2023_24"]["sha256"] == _sha256(
-        baseline_bytes
-    )
+    assert manifest["artifacts"]["frs_2023_24"]["sha256"] == _sha256(baseline_bytes)
     assert manifest["artifacts"]["local_authority_weights"]["kind"] == "weights"
 
 

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -20,21 +20,56 @@ RELEASE_MANIFEST_PATH = "release_manifest.json"
 
 def _get_model_package_version(
     package_name: str = "policyengine-uk",
-) -> str:
+) -> Optional[str]:
     try:
         return metadata.version(package_name)
     except metadata.PackageNotFoundError:
-        raise RuntimeError(
-            "Could not determine installed version for "
-            f"{package_name} while building a release manifest."
+        logging.warning(
+            "Could not determine installed version for %s while building release manifest.",
+            package_name,
         )
+        return None
+
+
+def _get_model_package_build_metadata(
+    package_name: str = "policyengine-uk",
+) -> Dict[str, Optional[str]]:
+    metadata_payload: Dict[str, Optional[str]] = {
+        "version": _get_model_package_version(package_name),
+        "git_sha": None,
+        "data_build_fingerprint": None,
+    }
+    module_name = package_name.replace("-", "_")
+    try:
+        build_metadata_module = __import__(
+            f"{module_name}.build_metadata",
+            fromlist=["get_data_build_metadata"],
+        )
+        get_data_build_metadata = getattr(
+            build_metadata_module, "get_data_build_metadata", None
+        )
+        if callable(get_data_build_metadata):
+            package_metadata = get_data_build_metadata()
+            metadata_payload["version"] = (
+                package_metadata.get("version") or metadata_payload["version"]
+            )
+            metadata_payload["git_sha"] = package_metadata.get("git_sha")
+            metadata_payload["data_build_fingerprint"] = package_metadata.get(
+                "data_build_fingerprint"
+            )
+    except Exception:
+        logging.warning(
+            "Could not load build metadata from %s while building release manifest.",
+            package_name,
+            exc_info=True,
+        )
+    return metadata_payload
 
 
 def load_release_manifest_from_hf(
     version: str,
     hf_repo_name: str = "policyengine/policyengine-uk-data-private",
     hf_repo_type: str = "model",
-    revision: Optional[str] = None,
 ) -> Optional[Dict]:
     token = os.environ.get("HUGGING_FACE_TOKEN")
     candidate_paths = [
@@ -49,10 +84,9 @@ def load_release_manifest_from_hf(
                 filename=path_in_repo,
                 repo_type=hf_repo_type,
                 token=token,
-                revision=revision,
             )
         except RevisionNotFoundError:
-            return None
+            raise
         except Exception:
             continue
 
@@ -66,59 +100,24 @@ def load_release_manifest_from_hf(
     return None
 
 
-def assert_release_not_finalized(
-    version: str,
-    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
-    hf_repo_type: str = "model",
-) -> None:
-    if (
-        load_release_manifest_from_hf(
-            version=version,
-            hf_repo_name=hf_repo_name,
-            hf_repo_type=hf_repo_type,
-            revision=version,
-        )
-        is not None
-    ):
-        raise RuntimeError(
-            f"Release {version} is already finalized on {hf_repo_name}. "
-            "Refusing to mutate release manifest state after the tag exists."
-        )
-
-
-def get_repo_head_revision(
-    api: HfApi,
-    repo_id: str,
-    repo_type: str,
-    token: Optional[str] = None,
-) -> Optional[str]:
-    repo_info = api.repo_info(
-        repo_id=repo_id,
-        repo_type=repo_type,
-        token=token,
-    )
-    return getattr(repo_info, "sha", None)
-
-
 def create_release_manifest_commit_operations(
     files_with_repo_paths: List[Tuple[Path, str]],
     version: str,
     hf_repo_name: str = "policyengine/policyengine-uk-data-private",
     model_package_name: str = "policyengine-uk",
     model_package_version: Optional[str] = None,
+    model_package_git_sha: Optional[str] = None,
+    model_package_data_build_fingerprint: Optional[str] = None,
     existing_manifest: Optional[Dict] = None,
 ) -> Tuple[Dict, List[CommitOperationAdd]]:
-    if not model_package_version:
-        raise RuntimeError(
-            "A compatible policyengine-uk version is required when publishing "
-            "a release manifest."
-        )
     manifest = build_release_manifest(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
         repo_id=hf_repo_name,
         model_package_name=model_package_name,
         model_package_version=model_package_version,
+        model_package_git_sha=model_package_git_sha,
+        model_package_data_build_fingerprint=model_package_data_build_fingerprint,
         existing_manifest=existing_manifest,
     )
     manifest_payload = serialize_release_manifest(manifest)
@@ -138,14 +137,14 @@ def create_release_manifest_commit_operations(
 def upload_data_files(
     files: List[str],
     gcs_bucket_name: str = "policyengine-uk-data-private",
-    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
+    hf_repo_name: str = "policyengine/policyengine-uk-data",
     hf_repo_type: str = "model",
     version: str = None,
 ):
     if version is None:
         version = metadata.version("policyengine-uk-data")
 
-    commit_oid = upload_files_to_hf(
+    upload_files_to_hf(
         files=files,
         version=version,
         hf_repo_name=hf_repo_name,
@@ -156,13 +155,6 @@ def upload_data_files(
         files=files,
         version=version,
         gcs_bucket_name=gcs_bucket_name,
-    )
-
-    create_release_tag(
-        version=version,
-        revision=commit_oid,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
     )
 
 
@@ -178,11 +170,6 @@ def upload_files_to_hf(
     api = HfApi()
     token = os.environ.get(
         "HUGGING_FACE_TOKEN",
-    )
-    assert_release_not_finalized(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
     )
     hf_operations = []
     files_with_repo_paths = []
@@ -200,23 +187,21 @@ def upload_files_to_hf(
             )
         )
 
-    model_package_version = _get_model_package_version()
     existing_manifest = load_release_manifest_from_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
-    parent_commit = get_repo_head_revision(
-        api=api,
-        repo_id=hf_repo_name,
-        repo_type=hf_repo_type,
-        token=token,
-    )
+    model_build_metadata = _get_model_package_build_metadata()
     _, manifest_operations = create_release_manifest_commit_operations(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
         hf_repo_name=hf_repo_name,
-        model_package_version=model_package_version,
+        model_package_version=model_build_metadata["version"],
+        model_package_git_sha=model_build_metadata["git_sha"],
+        model_package_data_build_fingerprint=model_build_metadata[
+            "data_build_fingerprint"
+        ],
         existing_manifest=existing_manifest,
     )
     hf_operations.extend(manifest_operations)
@@ -227,58 +212,26 @@ def upload_files_to_hf(
         operations=hf_operations,
         repo_type=hf_repo_type,
         commit_message=f"Upload data files for version {version}",
-        parent_commit=parent_commit,
     )
     logging.info(f"Uploaded files to Hugging Face repository {hf_repo_name}.")
-    return commit_info.oid
 
-
-def create_release_tag(
-    version: str,
-    revision: str,
-    hf_repo_name: str = "policyengine/policyengine-uk-data-private",
-    hf_repo_type: str = "model",
-    token: Optional[str] = None,
-    api: Optional[HfApi] = None,
-) -> None:
-    api = api or HfApi()
-    token = token or os.environ.get("HUGGING_FACE_TOKEN")
+    # Tag commit with version
     try:
         api.create_tag(
             token=token,
             repo_id=hf_repo_name,
             tag=version,
-            revision=revision,
+            revision=commit_info.oid,
             repo_type=hf_repo_type,
-            exist_ok=False,
         )
         logging.info(
             f"Tagged commit with {version} in Hugging Face repository {hf_repo_name}."
         )
     except Exception as e:
         if "Tag reference exists already" in str(e) or "409" in str(e):
-            tagged_revision = getattr(
-                api.repo_info(
-                    repo_id=hf_repo_name,
-                    repo_type=hf_repo_type,
-                    revision=version,
-                    token=token,
-                ),
-                "sha",
-                None,
+            logging.warning(
+                f"Tag {version} already exists in {hf_repo_name}. Skipping tag creation."
             )
-            if tagged_revision == revision:
-                logging.info(
-                    "Tag %s already exists in %s and already points to %s.",
-                    version,
-                    hf_repo_name,
-                    revision,
-                )
-                return
-            raise RuntimeError(
-                f"Tag {version} already exists in {hf_repo_name} at "
-                f"{tagged_revision}; refusing to treat {revision} as finalized."
-            ) from e
         else:
             raise
 

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -42,7 +42,11 @@ def _base_manifest(
     *,
     version: str,
     data_package_name: str,
-    compatible_model_packages: Sequence[Dict[str, str]],
+    model_package_name: str,
+    model_package_version: str | None,
+    model_package_git_sha: str | None,
+    model_package_data_build_fingerprint: str | None,
+    build_id: str,
     created_at: str,
 ) -> Dict:
     manifest = {
@@ -51,21 +55,34 @@ def _base_manifest(
             "name": data_package_name,
             "version": version,
         },
-        "compatible_model_packages": list(compatible_model_packages),
+        "compatible_model_packages": [],
         "default_datasets": {},
         "created_at": created_at,
+        "build": {
+            "build_id": build_id,
+            "built_at": created_at,
+        },
         "artifacts": {},
     }
+    if (
+        model_package_version
+        or model_package_git_sha
+        or model_package_data_build_fingerprint
+    ):
+        manifest["build"]["built_with_model_package"] = {
+            "name": model_package_name,
+            "version": model_package_version,
+            "git_sha": model_package_git_sha,
+            "data_build_fingerprint": model_package_data_build_fingerprint,
+        }
+    if model_package_version:
+        manifest["compatible_model_packages"].append(
+            {
+                "name": model_package_name,
+                "specifier": f"=={model_package_version}",
+            }
+        )
     return manifest
-
-
-def _compatible_model_packages(
-    model_package_name: str,
-    model_package_version: str | None,
-) -> list[Dict[str, str]]:
-    if not model_package_version:
-        return []
-    return [{"name": model_package_name, "version": model_package_version}]
 
 
 def _normalize_existing_manifest(
@@ -77,7 +94,10 @@ def _normalize_existing_manifest(
     if existing_manifest is None:
         return None
     package = existing_manifest.get("data_package", {})
-    if package.get("name") != data_package_name or package.get("version") != version:
+    if (
+        package.get("name") != data_package_name
+        or package.get("version") != version
+    ):
         return None
     return deepcopy(dict(existing_manifest))
 
@@ -90,6 +110,9 @@ def build_release_manifest(
     data_package_name: str = "policyengine-uk-data",
     model_package_name: str = "policyengine-uk",
     model_package_version: str | None = None,
+    model_package_git_sha: str | None = None,
+    model_package_data_build_fingerprint: str | None = None,
+    build_id: str | None = None,
     existing_manifest: Mapping | None = None,
     default_datasets: Optional[Mapping[str, str]] = None,
     created_at: str | None = None,
@@ -100,24 +123,43 @@ def build_release_manifest(
         data_package_name=data_package_name,
     )
     manifest_timestamp = created_at or _utc_timestamp()
+    resolved_build_id = build_id or f"{data_package_name}-{version}"
 
     if manifest is None:
         manifest = _base_manifest(
             version=version,
             data_package_name=data_package_name,
-            compatible_model_packages=_compatible_model_packages(
-                model_package_name,
-                model_package_version,
-            ),
+            model_package_name=model_package_name,
+            model_package_version=model_package_version,
+            model_package_git_sha=model_package_git_sha,
+            model_package_data_build_fingerprint=model_package_data_build_fingerprint,
+            build_id=resolved_build_id,
             created_at=manifest_timestamp,
         )
     else:
         manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
-        manifest["created_at"] = manifest.get("created_at") or manifest_timestamp
-        manifest["compatible_model_packages"] = _compatible_model_packages(
-            model_package_name,
-            model_package_version,
-        )
+        manifest["created_at"] = manifest_timestamp
+        manifest.setdefault("build", {})
+        manifest["build"].setdefault("build_id", resolved_build_id)
+        manifest["build"].setdefault("built_at", manifest_timestamp)
+        if (
+            model_package_version
+            or model_package_git_sha
+            or model_package_data_build_fingerprint
+        ):
+            manifest["build"]["built_with_model_package"] = {
+                "name": model_package_name,
+                "version": model_package_version,
+                "git_sha": model_package_git_sha,
+                "data_build_fingerprint": model_package_data_build_fingerprint,
+            }
+        if model_package_version:
+            manifest["compatible_model_packages"] = [
+                {
+                    "name": model_package_name,
+                    "specifier": f"=={model_package_version}",
+                }
+            ]
 
     if default_datasets:
         manifest.setdefault("default_datasets", {}).update(default_datasets)

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -94,10 +94,7 @@ def _normalize_existing_manifest(
     if existing_manifest is None:
         return None
     package = existing_manifest.get("data_package", {})
-    if (
-        package.get("name") != data_package_name
-        or package.get("version") != version
-    ):
+    if package.get("name") != data_package_name or package.get("version") != version:
         return None
     return deepcopy(dict(existing_manifest))
 


### PR DESCRIPTION
## Summary
- add build ids, timestamps, and build-time model metadata to UK release manifests
- populate release-manifest uploads from policyengine_uk build metadata
- extend release manifest tests to cover the new provenance fields

## Testing
- uv run pytest policyengine_uk_data/tests/test_release_manifest.py
- uv run ruff check policyengine_uk_data/utils/release_manifest.py policyengine_uk_data/utils/data_upload.py policyengine_uk_data/tests/test_release_manifest.py
- python3 -m py_compile policyengine_uk_data/utils/release_manifest.py policyengine_uk_data/utils/data_upload.py policyengine_uk_data/tests/test_release_manifest.py