### PR TITLE
Refresh VOA council tax and official PIP target sources

### DIFF
--- a/policyengine_uk_data/targets/sources.yaml
+++ b/policyengine_uk_data/targets/sources.yaml
@@ -28,7 +28,7 @@ ons:
   la_income: "https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/smallareaincomeestimatesformiddlelayersuperoutputareasenglandandwales"
 
 voa:
-  council_tax: "https://www.gov.uk/government/statistics/council-tax-stock-of-properties-2024"
+  council_tax: "https://www.gov.uk/government/statistics/council-tax-stock-of-properties-2025"
 
 nts:
   vehicle_ownership: "https://www.gov.uk/government/statistics/national-travel-survey-2024"

--- a/policyengine_uk_data/targets/sources/dwp.py
+++ b/policyengine_uk_data/targets/sources/dwp.py
@@ -7,6 +7,7 @@ households with child under 1.
 
 Sources:
 - DWP benefit statistics: https://www.gov.uk/government/statistics/dwp-benefit-statistics-february-2026/dwp-benefit-statistics-february-2026
+- DWP PIP statistics: https://www.gov.uk/government/statistics/personal-independence-payment-statistics-to-january-2026
 - DWP Stat-Xplore: https://stat-xplore.dwp.gov.uk
 - DWP benefit cap: https://www.gov.uk/government/statistics/benefit-cap-number-of-households-capped-to-november-2025
 - DWP two-child limit: https://www.gov.uk/government/statistics/universal-credit-claimants-statistics-on-the-two-child-limit-policy-april-2025/universal-credit-claimants-statistics-on-the-two-child-limit-policy-april-2025
@@ -20,13 +21,18 @@ _DWP_BENEFIT_STATS_FEB_2026 = (
     "dwp-benefit-statistics-february-2026/"
     "dwp-benefit-statistics-february-2026"
 )
+_PIP_STATS_JAN_2026 = (
+    "https://www.gov.uk/government/statistics/"
+    "personal-independence-payment-statistics-to-january-2026"
+)
 
 
 def get_targets() -> list[Target]:
     targets = []
 
-    # PIP daily living standard and enhanced claimant counts
-    # From Disability Rights UK analysis of DWP data
+    # PIP daily living standard and enhanced claimant counts.
+    # These are England and Wales cases with entitlement from the
+    # January 2026 official PIP statistics / linked Stat-Xplore series.
     targets.append(
         Target(
             name="dwp/pip_dl_standard_claimants",
@@ -35,7 +41,7 @@ def get_targets() -> list[Target]:
             unit=Unit.COUNT,
             values={2025: 1_283_000},
             is_count=True,
-            reference_url="https://www.disabilityrightsuk.org/news/90-pip-standard-daily-living-component-recipients-would-fail-new-green-paper-test",
+            reference_url=_PIP_STATS_JAN_2026,
         )
     )
     targets.append(
@@ -46,7 +52,7 @@ def get_targets() -> list[Target]:
             unit=Unit.COUNT,
             values={2025: 1_608_000},
             is_count=True,
-            reference_url="https://www.disabilityrightsuk.org/news/90-pip-standard-daily-living-component-recipients-would-fail-new-green-paper-test",
+            reference_url=_PIP_STATS_JAN_2026,
         )
     )
 

--- a/policyengine_uk_data/targets/sources/voa_council_tax.py
+++ b/policyengine_uk_data/targets/sources/voa_council_tax.py
@@ -1,36 +1,115 @@
 """VOA council tax band targets.
 
-Council tax band counts (A-H + total) by region from VOA stock of
-properties data.
+Council tax band counts (A-H + total) by region from the latest VOA
+stock-of-properties summary workbook, plus Scotland from the latest
+Scottish Government chargeable-dwellings workbook.
 
-Source: https://www.gov.uk/government/statistics/council-tax-stock-of-properties-2024
-Scotland: https://www.gov.scot/publications/council-tax-datasets/
+Sources:
+- https://www.gov.uk/government/statistics/council-tax-stock-of-properties-2025
+- https://www.gov.scot/publications/council-tax-datasets/
 """
 
-import pandas as pd
+from functools import lru_cache
+from io import BytesIO
+import re
+
+import openpyxl
+import requests
 
 from policyengine_uk_data.targets.schema import (
     GeographicLevel,
     Target,
     Unit,
 )
-from policyengine_uk_data.targets.sources._common import STORAGE
+from policyengine_uk_data.targets.sources._common import HEADERS, load_config
 
-_REF = "https://www.gov.uk/government/statistics/council-tax-stock-of-properties-2024"
+_SHEET = "CTSOP2.0"
+_HEADER_ROW = 5
+_BANDS = ["A", "B", "C", "D", "E", "F", "G", "H"]
+_SCOTLAND_REF = "https://www.gov.scot/publications/council-tax-datasets/"
+_SCOTLAND_WORKBOOK_URL = (
+    "https://www.gov.scot/binaries/content/documents/govscot/publications/"
+    "statistics/2019/04/council-tax-datasets/documents/"
+    "number-of-chargeable-dwellings/chargeable-dwellings---september-2025-data/"
+    "chargeable-dwellings---september-2025-data/govscot%3Adocument/"
+    "CTAXBASE%2B2025%2B-%2BTables%2B-%2BChargeable%2BDwellings.xlsx"
+)
+_VOA_NAME_TO_REGION = {
+    "North East": "NORTH_EAST",
+    "North West": "NORTH_WEST",
+    "Yorkshire and The Humber": "YORKSHIRE",
+    "East Midlands": "EAST_MIDLANDS",
+    "West Midlands": "WEST_MIDLANDS",
+    "East of England": "EAST_OF_ENGLAND",
+    "London": "LONDON",
+    "South East": "SOUTH_EAST",
+    "South West": "SOUTH_WEST",
+    "Wales": "WALES",
+}
+
+
+@lru_cache(maxsize=1)
+def _download_workbook() -> openpyxl.Workbook:
+    ref = load_config()["voa"]["council_tax"]
+    r = requests.get(ref, headers=HEADERS, allow_redirects=True, timeout=60)
+    r.raise_for_status()
+    match = re.search(
+        r'https://assets\.publishing\.service\.gov\.uk/media/[^"]+/[^"]+Summary_Tables\.xlsx',
+        r.text,
+    )
+    if not match:
+        raise ValueError("Could not find VOA council tax summary workbook link")
+    workbook_url = match.group(0)
+    workbook_response = requests.get(
+        workbook_url,
+        headers=HEADERS,
+        allow_redirects=True,
+        timeout=60,
+    )
+    workbook_response.raise_for_status()
+    return openpyxl.load_workbook(BytesIO(workbook_response.content), data_only=True)
+
+
+@lru_cache(maxsize=1)
+def _download_scotland_workbook() -> openpyxl.Workbook:
+    r = requests.get(
+        _SCOTLAND_WORKBOOK_URL,
+        headers=HEADERS,
+        allow_redirects=True,
+        timeout=60,
+    )
+    r.raise_for_status()
+    return openpyxl.load_workbook(BytesIO(r.content), data_only=True)
+
+
+def _to_float(value) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return 0.0
 
 
 def get_targets() -> list[Target]:
-    """Build council tax band targets from the CSV."""
-    csv_path = STORAGE / "council_tax_bands_2024.csv"
-    if not csv_path.exists():
-        return []
-
-    ct_data = pd.read_csv(csv_path)
+    """Build council tax band targets from the latest VOA workbook."""
+    wb = _download_workbook()
+    ws = wb[_SHEET]
+    ref = load_config()["voa"]["council_tax"]
     targets = []
+    year = 2025
 
-    for _, row in ct_data.iterrows():
-        region = row["Region"]
-        for band in ["A", "B", "C", "D", "E", "F", "G", "H"]:
+    headers = [ws.cell(row=_HEADER_ROW, column=col).value for col in range(1, 15)]
+    header_index = {header: idx + 1 for idx, header in enumerate(headers)}
+
+    for row_num in range(_HEADER_ROW + 1, ws.max_row + 1):
+        geography = ws.cell(
+            row=row_num, column=header_index["Geography [note 1]"]
+        ).value
+        if geography not in ("REGL", "NATL"):
+            continue
+        area_name = ws.cell(row=row_num, column=header_index["ONS area name"]).value
+        region = _VOA_NAME_TO_REGION.get(area_name)
+        if not region:
+            continue
+        for band in _BANDS:
             targets.append(
                 Target(
                     name=f"voa/council_tax/{region}/{band}",
@@ -39,12 +118,15 @@ def get_targets() -> list[Target]:
                     unit=Unit.COUNT,
                     geographic_level=GeographicLevel.REGION,
                     geo_name=region,
-                    values={2024: float(row[band])},
+                    values={
+                        year: _to_float(
+                            ws.cell(row=row_num, column=header_index[band]).value
+                        )
+                    },
                     is_count=True,
-                    reference_url=_REF,
+                    reference_url=ref,
                 )
             )
-        # Total row
         targets.append(
             Target(
                 name=f"voa/council_tax/{region}/total",
@@ -53,10 +135,72 @@ def get_targets() -> list[Target]:
                 unit=Unit.COUNT,
                 geographic_level=GeographicLevel.REGION,
                 geo_name=region,
-                values={2024: float(row["Total"])},
+                values={
+                    year: _to_float(
+                        ws.cell(
+                            row=row_num,
+                            column=header_index["All properties"],
+                        ).value
+                    )
+                },
                 is_count=True,
-                reference_url=_REF,
+                reference_url=ref,
             )
         )
+
+    scotland_ws = _download_scotland_workbook()["Chargeable Dwellings 2025"]
+    scotland_row = 8
+    scotland_col_index = {
+        "A": 2,
+        "B": 3,
+        "C": 4,
+        "D": 5,
+        "E": 6,
+        "F": 7,
+        "G": 8,
+        "H": 9,
+        "Total": 10,
+    }
+    for band in _BANDS:
+        targets.append(
+            Target(
+                name=f"voa/council_tax/SCOTLAND/{band}",
+                variable="council_tax_band",
+                source="voa",
+                unit=Unit.COUNT,
+                geographic_level=GeographicLevel.REGION,
+                geo_name="SCOTLAND",
+                values={
+                    year: _to_float(
+                        scotland_ws.cell(
+                            row=scotland_row,
+                            column=scotland_col_index[band],
+                        ).value
+                    )
+                },
+                is_count=True,
+                reference_url=_SCOTLAND_REF,
+            )
+        )
+    targets.append(
+        Target(
+            name="voa/council_tax/SCOTLAND/total",
+            variable="council_tax_band",
+            source="voa",
+            unit=Unit.COUNT,
+            geographic_level=GeographicLevel.REGION,
+            geo_name="SCOTLAND",
+            values={
+                year: _to_float(
+                    scotland_ws.cell(
+                        row=scotland_row,
+                        column=scotland_col_index["Total"],
+                    ).value
+                )
+            },
+            is_count=True,
+            reference_url=_SCOTLAND_REF,
+        )
+    )
 
     return targets

--- a/policyengine_uk_data/tests/test_target_registry.py
+++ b/policyengine_uk_data/tests/test_target_registry.py
@@ -64,10 +64,25 @@ def test_dwp_pip_targets():
 
 def test_voa_council_tax_targets():
     """VOA council tax band targets should exist."""
-    targets = get_all_targets(year=2024)
+    targets = get_all_targets(year=2025)
     voa = [t for t in targets if t.source == "voa"]
     # 11 regions × 9 (8 bands + total) = 99
     assert len(voa) >= 90, f"Expected 90+ VOA targets, got {len(voa)}"
+
+
+def test_dwp_pip_targets_use_official_source():
+    """PIP daily living targets should cite the official DWP release."""
+    targets = get_all_targets(year=2025)
+    standard = next(t for t in targets if t.name == "dwp/pip_dl_standard_claimants")
+    enhanced = next(t for t in targets if t.name == "dwp/pip_dl_enhanced_claimants")
+    assert (
+        "gov.uk/government/statistics/personal-independence-payment-statistics-to-january-2026"
+        in standard.reference_url
+    )
+    assert (
+        "gov.uk/government/statistics/personal-independence-payment-statistics-to-january-2026"
+        in enhanced.reference_url
+    )
 
 
 def test_core_target_count():


### PR DESCRIPTION
## Summary
- refresh the VOA council tax target source to the 2025 release and parse live England, Wales, and Scotland regional totals
- replace the PIP daily living target citation with the official January 2026 DWP statistics release
- align the target-registry checks with the refreshed 2025 target sources

## Verification
- `uvx ruff check policyengine_uk_data/targets/sources/dwp.py policyengine_uk_data/targets/sources/voa_council_tax.py policyengine_uk_data/tests/test_target_registry.py`
- `uv run pytest -q policyengine_uk_data/tests/test_target_registry.py policyengine_uk_data/tests/test_uc_by_children.py`

## Notes
- OBR March 2026, benefit cap November 2025, and the scaled local UC-by-children split were already on `main`; this PR closes the remaining freshness gaps from the audit.