### PR TITLE
Publish TRACE TRO declarations for UK data releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,33 @@ If `../policyengine-uk` exists, you can run:
 ```sh
 make data-local
 ```
+
+## TRACE provenance output
+
+Each UK data release now publishes both:
+
+- `release_manifest.json`
+- `trace.tro.jsonld`
+
+The release manifest remains the operational source of truth for:
+
+- published artifact paths and checksums
+- build IDs and timestamps
+- build-time `policyengine-uk` provenance
+
+`trace.tro.jsonld` is a generated TRACE declaration built from that manifest. It gives a
+standards-based provenance export over the same release artifacts, including a
+composition fingerprint across the release manifest and the artifacts it describes.
+
+Important boundary:
+
+- the TRACE file does not replace the release manifest
+- the TRACE file does not decide model/data compatibility
+
+For the broader certified-bundle architecture, see
+[`policyengine.py` release bundles](https://github.com/PolicyEngine/policyengine.py/blob/main/docs/release-bundles.md)
+and the official [TRACE specification](https://transparency-certified.github.io/trace-specification/docs/specifications/).
+
+Because UK data is private, the TRACE declaration is especially useful: it can record
+hashes and artifact locations without exposing the underlying microdata bytes.
  

--- a/changelog.d/codex-trace-tro-export.changed.md
+++ b/changelog.d/codex-trace-tro-export.changed.md
@@ -1,0 +1,1 @@
+Publish TRACE TRO declarations alongside UK data release manifests on Hugging Face.

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -10,6 +10,7 @@ from policyengine_uk_data.utils.release_manifest import (
     RELEASE_MANIFEST_SCHEMA_VERSION,
     build_release_manifest,
 )
+from policyengine_uk_data.utils.trace_tro import TRACE_TRO_FILENAME
 
 
 def _write_file(path: Path, content: bytes) -> Path:
@@ -121,6 +122,8 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
     assert "enhanced_frs_2023_24.h5" in operation_paths
     assert "release_manifest.json" in operation_paths
     assert "releases/1.40.4/release_manifest.json" in operation_paths
+    assert TRACE_TRO_FILENAME in operation_paths
+    assert f"releases/1.40.4/{TRACE_TRO_FILENAME}" in operation_paths
 
     release_ops = [
         operation
@@ -129,5 +132,13 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
     ]
     assert len(release_ops) == 2
     for operation in release_ops:
+        assert isinstance(operation, CommitOperationAdd)
+        assert isinstance(operation.path_or_fileobj, BytesIO)
+
+    trace_ops = [
+        operation for operation in operations if operation.path_in_repo.endswith(".jsonld")
+    ]
+    assert len(trace_ops) == 2
+    for operation in trace_ops:
         assert isinstance(operation, CommitOperationAdd)
         assert isinstance(operation.path_or_fileobj, BytesIO)

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -136,7 +136,9 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
         assert isinstance(operation.path_or_fileobj, BytesIO)
 
     trace_ops = [
-        operation for operation in operations if operation.path_in_repo.endswith(".jsonld")
+        operation
+        for operation in operations
+        if operation.path_in_repo.endswith(".jsonld")
     ]
     assert len(trace_ops) == 2
     for operation in trace_ops:

--- a/policyengine_uk_data/tests/test_trace_tro.py
+++ b/policyengine_uk_data/tests/test_trace_tro.py
@@ -61,7 +61,10 @@ def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
         "PolicyEngine UK data release pipeline"
     )
     assert len(artifacts) == 3
-    assert arrangement["trov:hasArtifactLocation"][-1]["trov:path"] == "release_manifest.json"
+    assert (
+        arrangement["trov:hasArtifactLocation"][-1]["trov:path"]
+        == "release_manifest.json"
+    )
     assert performance["trov:contributedToArrangement"]["trov:arrangement"] == {
         "@id": "arrangement/0"
     }

--- a/policyengine_uk_data/tests/test_trace_tro.py
+++ b/policyengine_uk_data/tests/test_trace_tro.py
@@ -1,0 +1,95 @@
+import hashlib
+import json
+from pathlib import Path
+
+from policyengine_uk_data.utils.release_manifest import build_release_manifest
+from policyengine_uk_data.utils.trace_tro import (
+    TRACE_TRO_FILENAME,
+    build_trace_tro_from_release_manifest,
+    compute_trace_composition_fingerprint,
+    serialize_trace_tro,
+)
+
+
+def _write_file(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_compute_trace_composition_fingerprint_is_order_independent():
+    a = "b" * 64
+    b = "a" * 64
+
+    assert compute_trace_composition_fingerprint([a, b]) == (
+        compute_trace_composition_fingerprint([b, a])
+    )
+
+
+def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
+    enhanced_path = _write_file(
+        tmp_path / "enhanced_frs_2023_24.h5",
+        b"enhanced-frs",
+    )
+    baseline_path = _write_file(tmp_path / "frs_2023_24.h5", b"baseline-frs")
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[
+            (enhanced_path, "enhanced_frs_2023_24.h5"),
+            (baseline_path, "frs_2023_24.h5"),
+        ],
+        version="1.40.4",
+        repo_id="policyengine/policyengine-uk-data-private",
+        model_package_version="2.74.0",
+        model_package_git_sha="deadbeef",
+        model_package_data_build_fingerprint="sha256:fingerprint",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+    root = tro["@graph"][0]
+    composition = root["trov:hasComposition"]
+    artifacts = composition["trov:hasArtifact"]
+    arrangement = root["trov:hasArrangement"][0]
+    performance = root["trov:hasPerformance"][0]
+
+    assert tro["@context"][0]["trov"] == "https://w3id.org/trace/trov/0.1#"
+    assert root["trov:vocabularyVersion"] == "0.1"
+    assert root["schema:name"] == "policyengine-uk-data 1.40.4 release TRO"
+    assert root["trov:createdWith"]["schema:softwareVersion"] == "1.40.4"
+    assert root["trov:wasAssembledBy"]["schema:name"] == (
+        "PolicyEngine UK data release pipeline"
+    )
+    assert len(artifacts) == 3
+    assert arrangement["trov:hasArtifactLocation"][-1]["trov:path"] == "release_manifest.json"
+    assert performance["trov:contributedToArrangement"]["trov:arrangement"] == {
+        "@id": "arrangement/0"
+    }
+
+    manifest_hash = hashlib.sha256(
+        (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    ).hexdigest()
+    assert artifacts[-1]["trov:hash"]["trov:hashValue"] == manifest_hash
+
+    expected_fingerprint = compute_trace_composition_fingerprint(
+        [artifact["trov:hash"]["trov:hashValue"] for artifact in artifacts]
+    )
+    assert (
+        composition["trov:hasFingerprint"]["trov:hash"]["trov:hashValue"]
+        == expected_fingerprint
+    )
+
+
+def test_serialize_trace_tro_is_deterministic(tmp_path):
+    dataset_path = _write_file(tmp_path / "enhanced_frs_2023_24.h5", b"enhanced-frs")
+    manifest = build_release_manifest(
+        files_with_repo_paths=[(dataset_path, "enhanced_frs_2023_24.h5")],
+        version="1.40.4",
+        repo_id="policyengine/policyengine-uk-data-private",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+
+    assert serialize_trace_tro(tro) == serialize_trace_tro(tro)
+    assert TRACE_TRO_FILENAME == "trace.tro.jsonld"

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -14,6 +14,11 @@ from policyengine_uk_data.utils.release_manifest import (
     build_release_manifest,
     serialize_release_manifest,
 )
+from policyengine_uk_data.utils.trace_tro import (
+    TRACE_TRO_FILENAME,
+    build_trace_tro_from_release_manifest,
+    serialize_trace_tro,
+)
 
 RELEASE_MANIFEST_PATH = "release_manifest.json"
 
@@ -121,6 +126,9 @@ def create_release_manifest_commit_operations(
         existing_manifest=existing_manifest,
     )
     manifest_payload = serialize_release_manifest(manifest)
+    trace_tro_payload = serialize_trace_tro(
+        build_trace_tro_from_release_manifest(manifest)
+    )
     operations = [
         CommitOperationAdd(
             path_in_repo=RELEASE_MANIFEST_PATH,
@@ -129,6 +137,14 @@ def create_release_manifest_commit_operations(
         CommitOperationAdd(
             path_in_repo=f"releases/{version}/{RELEASE_MANIFEST_PATH}",
             path_or_fileobj=BytesIO(manifest_payload),
+        ),
+        CommitOperationAdd(
+            path_in_repo=TRACE_TRO_FILENAME,
+            path_or_fileobj=BytesIO(trace_tro_payload),
+        ),
+        CommitOperationAdd(
+            path_in_repo=f"releases/{version}/{TRACE_TRO_FILENAME}",
+            path_or_fileobj=BytesIO(trace_tro_payload),
         ),
     ]
     return manifest, operations

--- a/policyengine_uk_data/utils/trace_tro.py
+++ b/policyengine_uk_data/utils/trace_tro.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Iterable, Mapping
+
+TRACE_TRO_FILENAME = "trace.tro.jsonld"
+TRACE_TROV_VERSION = "0.1"
+TRACE_CONTEXT = [
+    {
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "trov": "https://w3id.org/trace/trov/0.1#",
+        "schema": "https://schema.org/",
+    }
+]
+
+
+def _hash_object(value: str) -> dict[str, str]:
+    return {
+        "trov:hashAlgorithm": "sha256",
+        "trov:hashValue": value,
+    }
+
+
+def _artifact_mime_type(path_in_repo: str) -> str | None:
+    suffix = path_in_repo.rsplit(".", 1)[-1].lower() if "." in path_in_repo else ""
+    return {
+        "h5": "application/x-hdf5",
+        "db": "application/vnd.sqlite3",
+        "json": "application/json",
+        "jsonld": "application/ld+json",
+        "npy": "application/octet-stream",
+        "npz": "application/octet-stream",
+        "csv": "text/csv",
+    }.get(suffix)
+
+
+def compute_trace_composition_fingerprint(
+    artifact_hashes: Iterable[str],
+) -> str:
+    digest = hashlib.sha256()
+    digest.update("".join(sorted(artifact_hashes)).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def build_trace_tro_from_release_manifest(
+    manifest: Mapping,
+    *,
+    release_manifest_path: str = "release_manifest.json",
+) -> dict:
+    data_package = manifest["data_package"]
+    created_at = manifest.get("created_at") or manifest.get("build", {}).get("built_at")
+    build = manifest.get("build", {})
+    build_id = build.get("build_id") or f"{data_package['name']}-{data_package['version']}"
+    built_with_model = build.get("built_with_model_package") or {}
+    artifact_items = sorted(manifest.get("artifacts", {}).items())
+
+    composition_artifacts = []
+    arrangement_locations = []
+    artifact_hashes = []
+
+    for index, (artifact_key, artifact) in enumerate(artifact_items):
+        artifact_id = f"composition/1/artifact/{index}"
+        artifact_hashes.append(artifact["sha256"])
+        artifact_entry = {
+            "@id": artifact_id,
+            "@type": "trov:ResearchArtifact",
+            "trov:hash": _hash_object(artifact["sha256"]),
+        }
+        mime_type = _artifact_mime_type(artifact["path"])
+        if mime_type is not None:
+            artifact_entry["trov:mimeType"] = mime_type
+        composition_artifacts.append(artifact_entry)
+        arrangement_locations.append(
+            {
+                "@id": f"arrangement/0/location/{index}",
+                "@type": "trov:ArtifactLocation",
+                "trov:artifact": {"@id": artifact_id},
+                "trov:path": artifact["path"],
+            }
+        )
+
+    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    release_manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
+    manifest_artifact_id = f"composition/1/artifact/{len(composition_artifacts)}"
+    artifact_hashes.append(release_manifest_hash)
+    composition_artifacts.append(
+        {
+            "@id": manifest_artifact_id,
+            "@type": "trov:ResearchArtifact",
+            "trov:hash": _hash_object(release_manifest_hash),
+            "trov:mimeType": "application/json",
+        }
+    )
+    arrangement_locations.append(
+        {
+            "@id": f"arrangement/0/location/{len(arrangement_locations)}",
+            "@type": "trov:ArtifactLocation",
+            "trov:artifact": {"@id": manifest_artifact_id},
+            "trov:path": release_manifest_path,
+        }
+    )
+
+    trs_description = {
+        "@id": "trs",
+        "@type": ["trov:TrustedResearchSystem", "schema:Organization"],
+        "schema:name": "PolicyEngine UK data release pipeline",
+        "schema:description": (
+            "PolicyEngine build and release workflow for versioned UK microdata artifacts."
+        ),
+    }
+
+    model_version = built_with_model.get("version")
+    model_name = built_with_model.get("name", "policyengine-uk")
+    model_fingerprint = built_with_model.get("data_build_fingerprint")
+    description = (
+        f"TRACE TRO for {data_package['name']} {data_package['version']} "
+        f"covering immutable release artifacts and the accompanying release manifest."
+    )
+    if model_version:
+        description += f" Built with {model_name} {model_version}."
+    if model_fingerprint:
+        description += f" Data-build fingerprint: {model_fingerprint}."
+
+    tro = {
+        "@context": TRACE_CONTEXT,
+        "@graph": [
+            {
+                "@id": "tro",
+                "@type": ["trov:TransparentResearchObject", "schema:CreativeWork"],
+                "trov:vocabularyVersion": TRACE_TROV_VERSION,
+                "schema:creator": data_package["name"],
+                "schema:name": f"{data_package['name']} {data_package['version']} release TRO",
+                "schema:description": description,
+                "schema:dateCreated": created_at,
+                "trov:wasAssembledBy": trs_description,
+                "trov:createdWith": {
+                    "@type": "schema:SoftwareApplication",
+                    "schema:name": data_package["name"],
+                    "schema:softwareVersion": data_package["version"],
+                },
+                "trov:hasComposition": {
+                    "@id": "composition/1",
+                    "@type": "trov:ArtifactComposition",
+                    "trov:hasFingerprint": {
+                        "@id": "fingerprint",
+                        "@type": "trov:CompositionFingerprint",
+                        "trov:hash": _hash_object(
+                            compute_trace_composition_fingerprint(artifact_hashes)
+                        ),
+                    },
+                    "trov:hasArtifact": composition_artifacts,
+                },
+                "trov:hasArrangement": [
+                    {
+                        "@id": "arrangement/0",
+                        "@type": "trov:ArtifactArrangement",
+                        "rdfs:comment": (
+                            f"Immutable release artifact arrangement for build {build_id}"
+                        ),
+                        "trov:hasArtifactLocation": arrangement_locations,
+                    }
+                ],
+                "trov:hasPerformance": [
+                    {
+                        "@id": "trp/0",
+                        "@type": "trov:TrustedResearchPerformance",
+                        "rdfs:comment": (
+                            f"Publication of release build {build_id} for "
+                            f"{data_package['name']} {data_package['version']}"
+                        ),
+                        "trov:wasConductedBy": {"@id": "trs"},
+                        "trov:startedAtTime": build.get("built_at") or created_at,
+                        "trov:endedAtTime": created_at,
+                        "trov:contributedToArrangement": {
+                            "@id": "trp/0/binding/0",
+                            "@type": "trov:ArrangementBinding",
+                            "trov:arrangement": {"@id": "arrangement/0"},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    return tro
+
+
+def serialize_trace_tro(tro: Mapping) -> bytes:
+    return (json.dumps(tro, indent=2, sort_keys=True) + "\n").encode("utf-8")

--- a/policyengine_uk_data/utils/trace_tro.py
+++ b/policyengine_uk_data/utils/trace_tro.py
@@ -52,7 +52,9 @@ def build_trace_tro_from_release_manifest(
     data_package = manifest["data_package"]
     created_at = manifest.get("created_at") or manifest.get("build", {}).get("built_at")
     build = manifest.get("build", {})
-    build_id = build.get("build_id") or f"{data_package['name']}-{data_package['version']}"
+    build_id = (
+        build.get("build_id") or f"{data_package['name']}-{data_package['version']}"
+    )
     built_with_model = build.get("built_with_model_package") or {}
     artifact_items = sorted(manifest.get("artifacts", {}).items())
 


### PR DESCRIPTION
## Summary
- add a TRACE TRO builder for UK data release manifests
- upload `trace.tro.jsonld` alongside the floating and versioned release manifests
- add focused regression coverage for TRO generation and HF commit operations

## Testing
- PYTHONPATH=/Users/maxghenis/PolicyEngine/_codex_prs/policyengine-uk-data-trace-tro-export /Users/maxghenis/PolicyEngine/policyengine-uk-data/.venv/bin/pytest /Users/maxghenis/PolicyEngine/_codex_prs/policyengine-uk-data-trace-tro-export/policyengine_uk_data/tests/test_release_manifest.py /Users/maxghenis/PolicyEngine/_codex_prs/policyengine-uk-data-trace-tro-export/policyengine_uk_data/tests/test_trace_tro.py
- /Users/maxghenis/PolicyEngine/policyengine-uk-data/.venv/bin/python -m ruff check policyengine_uk_data/utils/data_upload.py policyengine_uk_data/utils/release_manifest.py policyengine_uk_data/utils/trace_tro.py policyengine_uk_data/tests/test_release_manifest.py policyengine_uk_data/tests/test_trace_tro.py