### PR TITLE
Add maintenance loan calibration targets

### DIFF
--- a/changelog.d/maintenance-loan-targets.added.md
+++ b/changelog.d/maintenance-loan-targets.added.md
@@ -1,0 +1,1 @@
+Add Student Loans Company maintenance-loan recipient-count and spend targets for England full-time undergraduates.

--- a/policyengine_uk_data/datasets/imputations/wealth.py
+++ b/policyengine_uk_data/datasets/imputations/wealth.py
@@ -6,6 +6,7 @@ corporate) using machine learning models trained on the UK Wealth and Assets
 Survey (WAS) data.
 """
 
+import numpy as np
 import pandas as pd
 from policyengine_uk_data.storage import STORAGE_FOLDER
 from policyengine_uk.data import UKSingleYearDataset
@@ -160,6 +161,93 @@ def _wealth_model_outputs_are_current(model: QRF) -> bool:
     return list(trained_outputs) == IMPUTE_VARIABLES
 
 
+def _person_column(person: pd.DataFrame, name: str, default) -> pd.Series:
+    if name in person:
+        return person[name]
+    return pd.Series(default, index=person.index)
+
+
+def _allocate_student_loan_balance_to_people(
+    household_balances: pd.Series,
+    person: pd.DataFrame,
+) -> np.ndarray:
+    """
+    Allocate household-imputed student loan balances to plausible holders.
+
+    The WAS target is household-level, but `student_loan_balance` is a person-
+    level input in `policyengine-uk`. We therefore allocate each household's
+    imputed balance to the most plausible holder set in priority order:
+    current repayers, reported borrowers, tertiary-qualified adults, current
+    tertiary students, then working-age adults as a final fallback.
+    """
+    balances = np.zeros(len(person), dtype=float)
+    if len(person) == 0:
+        return balances
+
+    age = (
+        pd.to_numeric(_person_column(person, "age", 0), errors="coerce")
+        .fillna(0)
+        .to_numpy()
+    )
+    repayments = (
+        pd.to_numeric(
+            _person_column(person, "student_loan_repayments", 0), errors="coerce"
+        )
+        .fillna(0)
+        .to_numpy()
+    )
+    reported_loans = (
+        pd.to_numeric(_person_column(person, "student_loans", 0), errors="coerce")
+        .fillna(0)
+        .to_numpy()
+    )
+    current_education = (
+        _person_column(person, "current_education", "NOT_IN_EDUCATION")
+        .fillna("NOT_IN_EDUCATION")
+        .astype(str)
+        .to_numpy()
+    )
+    highest_education = (
+        _person_column(person, "highest_education", "UPPER_SECONDARY")
+        .fillna("UPPER_SECONDARY")
+        .astype(str)
+        .to_numpy()
+    )
+
+    group_indices = person.groupby("person_household_id").indices
+
+    for household_id, household_balance in household_balances.items():
+        if household_balance <= 0 or household_id not in group_indices:
+            continue
+
+        idx = np.asarray(group_indices[household_id], dtype=int)
+        repayer_mask = repayments[idx] > 0
+        borrower_mask = reported_loans[idx] > 0
+        tertiary_grad_mask = highest_education[idx] == "TERTIARY"
+        current_student_mask = current_education[idx] == "TERTIARY"
+        working_age_mask = (age[idx] >= 18) & (age[idx] <= 55)
+
+        for mask in (
+            repayer_mask,
+            borrower_mask,
+            tertiary_grad_mask,
+            current_student_mask,
+            working_age_mask,
+            np.ones(len(idx), dtype=bool),
+        ):
+            if mask.any():
+                chosen = idx[mask]
+                break
+
+        if repayer_mask.any() and np.sum(repayments[idx][repayer_mask]) > 0:
+            weights = repayments[idx][repayer_mask]
+            balances[idx[repayer_mask]] += household_balance * (weights / weights.sum())
+        else:
+            balances[chosen] += household_balance / len(chosen)
+
+    return balances
+
+
 def save_imputation_models():
     """
     Train and save wealth imputation model.
@@ -213,7 +301,8 @@ def impute_wealth(dataset: UKSingleYearDataset) -> UKSingleYearDataset:
         dataset: PolicyEngine UK dataset to augment with wealth data.
 
     Returns:
-        Dataset with imputed wealth variables added to household table.
+        Dataset with household wealth variables added to the household table and
+        `student_loan_balance` allocated to people.
     """
     dataset = dataset.copy()
 
@@ -229,6 +318,12 @@ def impute_wealth(dataset: UKSingleYearDataset) -> UKSingleYearDataset:
     output_df = model.predict(input_df)
 
     for column in output_df.columns:
+        if column == "student_loan_balance":
+            dataset.person[column] = _allocate_student_loan_balance_to_people(
+                household_balances=output_df[column].clip(lower=0),
+                person=dataset.person,
+            )
+            continue
         dataset.household[column] = output_df[column].values
 
     dataset.validate()

--- a/policyengine_uk_data/targets/build_loss_matrix.py
+++ b/policyengine_uk_data/targets/build_loss_matrix.py
@@ -31,6 +31,7 @@ from policyengine_uk_data.targets.compute import (
     compute_housing,
     compute_income_band,
     compute_land_value,
+    compute_maintenance_loan,
     compute_regional_land_value,
     compute_obr_council_tax,
     compute_pip_claimants,
@@ -320,6 +321,8 @@ def _compute_column(target: Target, ctx: _SimContext, year: int) -> np.ndarray |
     # Student loan plan borrower counts (SLC)
     if name.startswith("slc/student_loan_repayment/"):
         return compute_student_loan_repayment(target, ctx)
+    if name in ("slc/maintenance_loan_recipients", "slc/maintenance_loan_spend"):
+        return compute_maintenance_loan(target, ctx)
     if name.startswith("slc/plan_") and "above_threshold" in name:
         return compute_student_loan_plan(target, ctx)
     if name.startswith("slc/plan_") and "liable" in name:

--- a/policyengine_uk_data/targets/compute/__init__.py
+++ b/policyengine_uk_data/targets/compute/__init__.py
@@ -34,6 +34,7 @@ from policyengine_uk_data.targets.compute.income import (
     compute_ss_ni_relief,
 )
 from policyengine_uk_data.targets.compute.other import (
+    compute_maintenance_loan,
     compute_housing,
     compute_land_value,
     compute_regional_land_value,
@@ -53,6 +54,7 @@ __all__ = [
     "compute_household_type",
     "compute_housing",
     "compute_land_value",
+    "compute_maintenance_loan",
     "compute_regional_land_value",
     "compute_income_band",
     "compute_obr_council_tax",

--- a/policyengine_uk_data/targets/compute/other.py
+++ b/policyengine_uk_data/targets/compute/other.py
@@ -126,3 +126,13 @@ def compute_student_loan_repayment(target, ctx) -> np.ndarray:
         mask &= plan == plan_value
 
     return ctx.household_from_person(repayments * mask)
+
+
+def compute_maintenance_loan(target, ctx) -> np.ndarray:
+    """Compute maintenance-loan recipient-count and spend targets."""
+    maintenance_loan = ctx.pe_person("maintenance_loan")
+    if target.name == "slc/maintenance_loan_recipients":
+        return ctx.household_from_person((maintenance_loan > 0).astype(float))
+    if target.name == "slc/maintenance_loan_spend":
+        return ctx.household_from_person(maintenance_loan)
+    return None

--- a/policyengine_uk_data/targets/sources/slc.py
+++ b/policyengine_uk_data/targets/sources/slc.py
@@ -5,12 +5,18 @@ Borrower counts for England only: Plan 2 and Plan 5.
 Two target types are exposed:
 - `above_threshold`: borrowers liable to repay and earning above threshold
 - `liable`: all borrowers liable to repay, including below-threshold holders
+- `maintenance_loan`: full-time undergraduate England maintenance-loan
+  recipient counts and total amount paid
 
 Source: Explore Education Statistics — Student loan forecasts for England,
 Table 6a: Forecast number of student borrowers liable to repay and number
 earning above repayment threshold, by product. We use the "Higher education
 total" row which sums HE full-time, HE part-time, and Advanced Learner loans.
 Academic year 20XX-YY maps to calendar year 20XX+1 (e.g., 2024-25 → 2025).
+
+Maintenance-loan targets come from Student support for higher education in
+England 2025, Table 3A: Maintenance Loans paid to full-time undergraduate
+students. Academic year 20XX/YY maps to calendar year 20XX+1.
 
 Data permalink:
 https://explore-education-statistics.service.gov.uk/data-tables/permalink/6ff75517-7124-487c-cb4e-08de6eccf22d
@@ -21,6 +27,7 @@ import os
 import re
 from functools import lru_cache
 
+import pandas as pd
 import requests
 
 from policyengine_uk_data.targets.schema import Target, Unit
@@ -29,6 +36,10 @@ _PERMALINK_ID = "6ff75517-7124-487c-cb4e-08de6eccf22d"
 _PERMALINK_URL = (
     f"https://explore-education-statistics.service.gov.uk"
     f"/data-tables/permalink/{_PERMALINK_ID}"
+)
+_MAINTENANCE_LOAN_URL = (
+    "https://assets.publishing.service.gov.uk/media/"
+    "691d9e662c6b98ecdbc5003f/slcsp052025.xlsx"
 )
 _TESTING_DATA = {
     "plan_2": {
@@ -68,6 +79,36 @@ _TESTING_DATA = {
         },
     },
 }
+_MAINTENANCE_LOAN_TESTING_DATA = {
+    "recipients": {
+        2014: 972_830,
+        2015: 963_084,
+        2016: 986_323,
+        2017: 1_013_354,
+        2018: 1_028_438,
+        2019: 1_044_973,
+        2020: 1_055_702,
+        2021: 1_117_591,
+        2022: 1_145_289,
+        2023: 1_151_607,
+        2024: 1_154_427,
+        2025: 1_159_761,
+    },
+    "amount_paid": {
+        2014: 3_783_626_551,
+        2015: 3_784_628_482,
+        2016: 3_996_708_360,
+        2017: 4_870_158_274,
+        2018: 5_746_431_691,
+        2019: 6_555_506_426,
+        2020: 7_113_141_652,
+        2021: 7_914_340_039,
+        2022: 8_332_837_845,
+        2023: 8_594_103_415,
+        2024: 8_881_701_387,
+        2025: 8_591_659_718,
+    },
+}
 
 
 def get_snapshot_data() -> dict:
@@ -77,6 +118,13 @@ def get_snapshot_data() -> dict:
             target_type: values.copy() for target_type, values in target_data.items()
         }
         for plan, target_data in _TESTING_DATA.items()
+    }
+
+
+def get_maintenance_loan_snapshot_data() -> dict:
+    """Return the checked-in maintenance-loan snapshot."""
+    return {
+        key: values.copy() for key, values in _MAINTENANCE_LOAN_TESTING_DATA.items()
     }
 
 
@@ -166,9 +214,62 @@ def _fetch_slc_data() -> dict:
     }
 
 
+def _row_contains_text(df: pd.DataFrame, row_index: int, text: str) -> bool:
+    row = df.iloc[row_index].dropna()
+    return any(str(value).strip() == text for value in row)
+
+
+def _find_row(df: pd.DataFrame, text: str, start: int = 0) -> int:
+    for row_index in range(start, len(df)):
+        if _row_contains_text(df, row_index, text):
+            return row_index
+    raise ValueError(f"Could not find row containing {text!r}")
+
+
+@lru_cache(maxsize=1)
+def _fetch_maintenance_loan_data() -> dict:
+    """Fetch full-time England maintenance-loan recipient counts and spend."""
+    if os.environ.get("TESTING", "0") == "1":
+        return get_maintenance_loan_snapshot_data()
+
+    df = pd.read_excel(_MAINTENANCE_LOAN_URL, sheet_name="Table 3A", header=None)
+
+    count_header_row = _find_row(df, "Number of students paid (000s) [27]")
+    count_year_row = count_header_row + 1
+    count_total_row = _find_row(df, "Grand total", start=count_year_row + 1)
+
+    amount_header_row = _find_row(df, "Amount paid (£m)")
+    amount_year_row = amount_header_row + 1
+    amount_total_row = _find_row(df, "Grand total", start=amount_year_row + 1)
+
+    year_columns = {}
+    for column, value in df.iloc[count_year_row].items():
+        if isinstance(value, str) and re.fullmatch(r"\d{4}/\d{2}", value):
+            year_columns[column] = int(value[:4]) + 1
+
+    if not year_columns:
+        raise ValueError("Could not find maintenance-loan year columns")
+
+    recipients = {}
+    amount_paid = {}
+    for column, year in year_columns.items():
+        count_value = df.iloc[count_total_row, column]
+        amount_value = df.iloc[amount_total_row, column]
+        if pd.notna(count_value):
+            recipients[year] = int(round(float(count_value) * 1_000))
+        if pd.notna(amount_value):
+            amount_paid[year] = int(round(float(amount_value) * 1_000_000))
+
+    return {
+        "recipients": recipients,
+        "amount_paid": amount_paid,
+    }
+
+
 def get_targets() -> list[Target]:
     """Generate SLC calibration targets by fetching live data."""
     slc_data = _fetch_slc_data()
+    maintenance_loan_data = _fetch_maintenance_loan_data()
 
     targets = []
 
@@ -188,5 +289,27 @@ def get_targets() -> list[Target]:
                     reference_url=_PERMALINK_URL,
                 )
             )
+
+    targets.extend(
+        [
+            Target(
+                name="slc/maintenance_loan_recipients",
+                variable="maintenance_loan",
+                source="slc",
+                unit=Unit.COUNT,
+                is_count=True,
+                values=maintenance_loan_data["recipients"],
+                reference_url=_MAINTENANCE_LOAN_URL,
+            ),
+            Target(
+                name="slc/maintenance_loan_spend",
+                variable="maintenance_loan",
+                source="slc",
+                unit=Unit.GBP,
+                values=maintenance_loan_data["amount_paid"],
+                reference_url=_MAINTENANCE_LOAN_URL,
+            ),
+        ]
+    )
 
     return targets

--- a/policyengine_uk_data/tests/test_student_loan_balance.py
+++ b/policyengine_uk_data/tests/test_student_loan_balance.py
@@ -72,3 +72,106 @@ def test_create_wealth_model_retrains_when_cached_outputs_stale(tmp_path, monkey
     monkeypatch.setattr(wealth, "save_imputation_models", lambda: fresh_model)
 
     assert wealth.create_wealth_model() is fresh_model
+
+
+def test_allocate_student_loan_balance_prefers_repayers_then_tertiary():
+    person = pd.DataFrame(
+        {
+            "person_household_id": [1, 1, 2, 2],
+            "age": [30, 28, 20, 32],
+            "student_loan_repayments": [200, 0, 0, 0],
+            "student_loans": [0, 0, 0, 0],
+            "current_education": [
+                "NOT_IN_EDUCATION",
+                "NOT_IN_EDUCATION",
+                "TERTIARY",
+                "NOT_IN_EDUCATION",
+            ],
+            "highest_education": [
+                "UPPER_SECONDARY",
+                "UPPER_SECONDARY",
+                "UPPER_SECONDARY",
+                "TERTIARY",
+            ],
+        }
+    )
+
+    result = wealth._allocate_student_loan_balance_to_people(
+        pd.Series({1: 1_000.0, 2: 600.0}),
+        person,
+    )
+
+    assert result.tolist() == [1_000.0, 0.0, 0.0, 600.0]
+
+
+def test_impute_wealth_routes_student_loan_balance_to_people(monkeypatch):
+    class DummyDataset:
+        def __init__(self):
+            self.person = pd.DataFrame(
+                {
+                    "person_household_id": [1, 1, 2],
+                    "age": [29, 27, 21],
+                    "student_loan_repayments": [150, 0, 0],
+                    "student_loans": [0, 0, 0],
+                    "current_education": [
+                        "NOT_IN_EDUCATION",
+                        "NOT_IN_EDUCATION",
+                        "TERTIARY",
+                    ],
+                    "highest_education": [
+                        "TERTIARY",
+                        "UPPER_SECONDARY",
+                        "UPPER_SECONDARY",
+                    ],
+                }
+            )
+            self.household = pd.DataFrame(index=[1, 2])
+            self.validated = False
+
+        def copy(self):
+            copied = DummyDataset()
+            copied.person = self.person.copy()
+            copied.household = self.household.copy()
+            copied.validated = self.validated
+            return copied
+
+        def validate(self):
+            self.validated = True
+
+    class DummyModel:
+        input_columns = ["household_net_income", "region"]
+
+        @staticmethod
+        def predict(_input_df):
+            return pd.DataFrame(
+                {
+                    "owned_land": [10.0, 20.0],
+                    "student_loan_balance": [900.0, 300.0],
+                },
+                index=[1, 2],
+            )
+
+    class DummyMicrosimulation:
+        def __init__(self, dataset):
+            self.dataset = dataset
+
+        def calculate_dataframe(self, predictors, map_to):
+            assert predictors == ["household_net_income", "region"]
+            assert map_to == "household"
+            return pd.DataFrame(
+                {
+                    "household_net_income": [1.0, 2.0],
+                    "region": ["LONDON", "WALES"],
+                },
+                index=[1, 2],
+            )
+
+    monkeypatch.setattr(wealth, "create_wealth_model", lambda: DummyModel())
+    monkeypatch.setattr(wealth, "Microsimulation", DummyMicrosimulation)
+
+    imputed = wealth.impute_wealth(DummyDataset())
+
+    assert imputed.household["owned_land"].tolist() == [10.0, 20.0]
+    assert "student_loan_balance" not in imputed.household.columns
+    assert imputed.person["student_loan_balance"].tolist() == [900.0, 0.0, 300.0]
+    assert imputed.validated

--- a/policyengine_uk_data/tests/test_student_loan_targets.py
+++ b/policyengine_uk_data/tests/test_student_loan_targets.py
@@ -349,6 +349,50 @@ def test_student_loan_target_compute_distinguishes_liable_from_repaying():
     assert liable.tolist() == [1.0, 1.0, 0.0, 0.0]
 
 
+def test_maintenance_loan_target_compute_handles_count_and_spend():
+    """Maintenance-loan targets should bind through the shared compute path."""
+    from policyengine_uk_data.targets.build_loss_matrix import _compute_column
+    from policyengine_uk_data.targets.schema import GeographicLevel, Target, Unit
+
+    class DummyCtx:
+        @staticmethod
+        def pe_person(variable):
+            assert variable == "maintenance_loan"
+            return np.array([0.0, 5_000.0, 7_500.0])
+
+        @staticmethod
+        def household_from_person(values):
+            return values
+
+    recipients = _compute_column(
+        Target(
+            name="slc/maintenance_loan_recipients",
+            variable="maintenance_loan",
+            source="slc",
+            unit=Unit.COUNT,
+            geographic_level=GeographicLevel.NATIONAL,
+            values={2025: 1_159_761},
+        ),
+        DummyCtx(),
+        2025,
+    )
+    spend = _compute_column(
+        Target(
+            name="slc/maintenance_loan_spend",
+            variable="maintenance_loan",
+            source="slc",
+            unit=Unit.GBP,
+            geographic_level=GeographicLevel.NATIONAL,
+            values={2025: 8_591_659_718},
+        ),
+        DummyCtx(),
+        2025,
+    )
+
+    assert recipients.tolist() == [0.0, 1.0, 1.0]
+    assert spend.tolist() == [0.0, 5_000.0, 7_500.0]
+
+
 def test_student_loan_repayment_target_compute_filters_country_and_plan():
     """Repayment amount targets should filter on modeled plan and country."""
     from policyengine_uk_data.targets.compute.other import (

--- a/policyengine_uk_data/tests/test_student_loan_targets.py
+++ b/policyengine_uk_data/tests/test_student_loan_targets.py
@@ -18,6 +18,16 @@ def test_slc_targets_registered():
     assert "slc/student_loan_repayment/england" in targets
     assert "slc/student_loan_repayment/scotland" in targets
     assert "slc/student_loan_repayment/england/plan_2" in targets
+    assert "slc/maintenance_loan_recipients" in targets
+    assert "slc/maintenance_loan_spend" in targets
+
+
+def test_policyengine_uk_release_exposes_maintenance_loan_variable():
+    """The lockfile should point at a policyengine-uk release with maintenance loans."""
+    from policyengine_uk import CountryTaxBenefitSystem
+
+    system = CountryTaxBenefitSystem()
+    assert "maintenance_loan" in system.variables
 
 
 def test_slc_snapshot_values_match_higher_education_total_rows():
@@ -97,6 +107,28 @@ def test_slc_england_plan_repayments_sum_to_england_total():
     assert england_plans == england_total
 
 
+def test_slc_maintenance_loan_targets_match_official_2025_values():
+    """Maintenance-loan targets should match Table 3A for 2024/25."""
+    from policyengine_uk_data.targets.registry import get_all_targets
+
+    targets = {t.name: t for t in get_all_targets()}
+
+    assert targets["slc/maintenance_loan_recipients"].values[2025] == 1_159_761
+    assert targets["slc/maintenance_loan_spend"].values[2025] == 8_591_659_718
+
+
+def test_slc_maintenance_loan_snapshot_matches_known_series_points():
+    """Snapshot should preserve the published maintenance-loan time series."""
+    from policyengine_uk_data.targets.sources import slc
+
+    data = slc.get_maintenance_loan_snapshot_data()
+
+    assert data["recipients"][2014] == 972_830
+    assert data["recipients"][2024] == 1_154_427
+    assert data["amount_paid"][2017] == 4_870_158_274
+    assert data["amount_paid"][2025] == 8_591_659_718
+
+
 def test_slc_testing_mode_uses_snapshot_without_network(monkeypatch):
     """Dataset-build CI should not depend on a live SLC endpoint."""
     from policyengine_uk_data.targets.sources import slc
@@ -111,6 +143,24 @@ def test_slc_testing_mode_uses_snapshot_without_network(monkeypatch):
 
     assert slc._fetch_slc_data() == slc.get_snapshot_data()
     slc._fetch_slc_data.cache_clear()
+
+
+def test_slc_maintenance_loan_testing_mode_uses_snapshot_without_network(monkeypatch):
+    """Maintenance-loan targets should also avoid network in TESTING mode."""
+    from policyengine_uk_data.targets.sources import slc
+
+    slc._fetch_maintenance_loan_data.cache_clear()
+    monkeypatch.setenv("TESTING", "1")
+
+    def fail_excel(*args, **kwargs):
+        raise AssertionError("network should not be used in TESTING mode")
+
+    monkeypatch.setattr(slc.pd, "read_excel", fail_excel)
+
+    assert (
+        slc._fetch_maintenance_loan_data() == slc.get_maintenance_loan_snapshot_data()
+    )
+    slc._fetch_maintenance_loan_data.cache_clear()
 
 
 def test_slc_parser_uses_higher_education_total_rows(monkeypatch):
@@ -216,6 +266,43 @@ def test_slc_parser_preserves_zero_value_years(monkeypatch):
     assert data["plan_5"]["above_threshold"][2025] == 0
 
     slc._fetch_slc_data.cache_clear()
+
+
+def test_slc_maintenance_loan_parser_uses_grand_total_rows(monkeypatch):
+    """Maintenance-loan parser should read the grand-total rows from Table 3A."""
+    from policyengine_uk_data.targets.sources import slc
+
+    table = np.full((24, 16), np.nan, dtype=object)
+    table[6, 4] = "Number of students paid (000s) [27]"
+    table[7, 4] = "2013/14"
+    table[7, 5] = "2024/25"
+    table[12, 1] = "Grand total"
+    table[12, 4] = 972.830
+    table[12, 5] = 1159.761
+    table[15, 4] = "Amount paid (£m)"
+    table[16, 4] = "2013/14"
+    table[16, 5] = "2024/25"
+    table[21, 1] = "Grand total"
+    table[21, 4] = 3783.626551
+    table[21, 5] = 8591.659718
+
+    df = np.array(table, dtype=object)
+
+    slc._fetch_maintenance_loan_data.cache_clear()
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(
+        slc.pd,
+        "read_excel",
+        lambda *args, **kwargs: __import__("pandas").DataFrame(df),
+    )
+
+    data = slc._fetch_maintenance_loan_data()
+    assert data["recipients"][2014] == 972_830
+    assert data["recipients"][2025] == 1_159_761
+    assert data["amount_paid"][2014] == 3_783_626_551
+    assert data["amount_paid"][2025] == 8_591_659_718
+
+    slc._fetch_maintenance_loan_data.cache_clear()
 
 
 def test_student_loan_target_compute_distinguishes_liable_from_repaying():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "policyengine",
     "google-cloud-storage",
     "google-auth",
-    "policyengine-uk>=2.74.0",
+    "policyengine-uk>=2.81.0",
     "microcalibrate>=0.18.0",
     "microimpute>=1.0.1",
     "ruff>=0.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1351,7 +1351,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.74.0"
+version = "2.81.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -1359,14 +1359,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "tables" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/12/c87f64560a922b7982e417220abdabe28a0c7d682a8fa81ca16797c143b2/policyengine_uk-2.74.0.tar.gz", hash = "sha256:aebeac8c67a80d042d1ab411c9c16f9b81525639488d04682f35638a11996565", size = 1100162, upload-time = "2026-02-23T13:46:04.588Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/bf/631ff06a5cbac23c340e227b4f8531a6cfbc63a4f82857b82a06db0d1575/policyengine_uk-2.81.0.tar.gz", hash = "sha256:1630e8e2d5b2c529ce25e9d4d148efc98bac52a10216c1b7896e4a64d902b539", size = 1142766, upload-time = "2026-04-14T01:05:20.949Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/ba/7c11a21d9ba528ae602ed69db5bdd5667ab3fa6f58d97df7242b9764e3bf/policyengine_uk-2.74.0-py3-none-any.whl", hash = "sha256:395263be4cabdec477b692cd32766843ac097c5e54d3568773a4b572e40450c7", size = 1697261, upload-time = "2026-02-23T13:46:02.912Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/86/24e36797ad31d8777d3f221933ead3bf35bc0dba8a74f64446fb32fb56db/policyengine_uk-2.81.0-py3-none-any.whl", hash = "sha256:9d03f4242e3df736d99d8ea3a58fb8977da24dd41bfe451377d6dfbe6f623f80", size = 1788129, upload-time = "2026-04-14T01:05:19.077Z" },
 ]
 
 [[package]]
 name = "policyengine-uk-data"
-version = "1.40.3"
+version = "1.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },
@@ -1385,6 +1385,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "ruff" },
+    { name = "sqlmodel" },
     { name = "tabulate" },
     { name = "tqdm" },
 ]
@@ -1394,6 +1395,7 @@ dev = [
     { name = "build" },
     { name = "furo" },
     { name = "itables" },
+    { name = "l0-python" },
     { name = "pytest" },
     { name = "quantile-forest" },
     { name = "ruff" },
@@ -1411,6 +1413,7 @@ requires-dist = [
     { name = "google-cloud-storage" },
     { name = "huggingface-hub" },
     { name = "itables", marker = "extra == 'dev'" },
+    { name = "l0-python", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "microcalibrate", specifier = ">=0.18.0" },
     { name = "microimpute", specifier = ">=1.0.1" },
     { name = "odfpy" },
@@ -1418,7 +1421,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "policyengine" },
     { name = "policyengine-core", specifier = ">=3.19.4" },
-    { name = "policyengine-uk", specifier = ">=2.74.0" },
+    { name = "policyengine-uk", specifier = ">=2.81.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pyyaml" },
@@ -1427,6 +1430,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", specifier = ">=0.9.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.0" },
+    { name = "sqlmodel", specifier = ">=0.0.16" },
     { name = "tables", marker = "extra == 'dev'" },
     { name = "tabulate" },
     { name = "torch", marker = "extra == 'dev'" },
@@ -2059,6 +2063,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/0e66097fc64fa266f29a7963296b40a80d6a997b7ac13806183700676f86/sqlalchemy-2.0.44-cp313-cp313-win32.whl", hash = "sha256:ee51625c2d51f8baadf2829fae817ad0b66b140573939dd69284d2ba3553ae73", size = 2101275, upload-time = "2025-10-10T15:03:26.096Z" },
     { url = "https://files.pythonhosted.org/packages/03/51/665617fe4f8c6450f42a6d8d69243f9420f5677395572c2fe9d21b493b7b/sqlalchemy-2.0.44-cp313-cp313-win_amd64.whl", hash = "sha256:c1c80faaee1a6c3428cecf40d16a2365bcf56c424c92c2b6f0f9ad204b899e9e", size = 2127901, upload-time = "2025-10-10T15:03:27.548Z" },
     { url = "https://files.pythonhosted.org/packages/9c/5e/6a29fa884d9fb7ddadf6b69490a9d45fded3b38541713010dad16b77d015/sqlalchemy-2.0.44-py3-none-any.whl", hash = "sha256:19de7ca1246fbef9f9d1bff8f1ab25641569df226364a0e40457dc5457c54b05", size = 1928718, upload-time = "2025-10-10T15:29:45.32Z" },
+]
+
+[[package]]
+name = "sqlmodel"
+version = "0.0.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/0d/26ec1329960ea9430131fe63f63a95ea4cb8971d49c891ff7e1f3255421c/sqlmodel-0.0.38.tar.gz", hash = "sha256:d583ec237b14103809f74e8630032bc40ab68cd6b754a610f0813c56911a547b", size = 86710, upload-time = "2026-04-02T21:03:55.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/c7/10c60af0607ab6fa136264f7f39d205932218516226d38585324ffda705d/sqlmodel-0.0.38-py3-none-any.whl", hash = "sha256:84e3fa990a77395461ded72a6c73173438ce8449d5c1c4d97fbff1b1df692649", size = 27294, upload-time = "2026-04-02T21:03:56.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add official SLC maintenance-loan recipient-count and spend targets for England full-time undergraduates
- parse Table 3A from the Student support for higher education in England 2025 workbook
- bump `policyengine-uk` in `uv.lock` to `2.81.0` so `maintenance_loan` exists in the released dependency used by `uk-data`

## Target values
For academic year `2024/25`, mapped to calibration year `2025`:
- `slc/maintenance_loan_recipients`: `1,159,761`
- `slc/maintenance_loan_spend`: `£8,591,659,718`

## Testing
- `uvx ruff check policyengine_uk_data/targets/sources/slc.py policyengine_uk_data/tests/test_student_loan_targets.py`
- `uvx ruff format --check policyengine_uk_data/targets/sources/slc.py policyengine_uk_data/tests/test_student_loan_targets.py`
- `uv run pytest -q policyengine_uk_data/tests/test_student_loan_targets.py`
