### PR TITLE
Split reported education grants

### DIFF
--- a/changelog.d/341.md
+++ b/changelog.d/341.md
@@ -1,0 +1,1 @@
+Split specific student-finance grant capacity out of the generic FRS education-grants residual and seed Disabled Students' Allowance expenses where reported grants plausibly identify DSA (#341).

--- a/policyengine_uk_data/datasets/frs.py
+++ b/policyengine_uk_data/datasets/frs.py
@@ -35,6 +35,19 @@ ESA_HEALTH_EMPLOYMENT_STATUSES = (
     EmploymentStatus.LONG_TERM_DISABLED.name,
     EmploymentStatus.SHORT_TERM_DISABLED.name,
 )
+REPORTED_EDUCATION_GRANT_VARIABLES = (
+    "childcare_grant",
+    "parents_learning_allowance",
+    "adult_dependants_grant",
+)
+DISABLED_STUDENTS_ALLOWANCE_EXPENSE_INPUT = (
+    "disabled_students_allowance_eligible_expenses"
+)
+DISABLED_STUDENTS_ALLOWANCE_ELIGIBILITY_VARIABLES = (
+    "maintenance_loan_in_england_system",
+    "disabled_students_allowance_course_eligible",
+    "disabled_students_allowance_has_qualifying_condition",
+)
 
 
 @lru_cache(maxsize=None)
@@ -212,6 +225,97 @@ def attach_legacy_benefit_proxies_from_frs_person(
         year,
         employment_status_reported=employment_status_reported,
     )
+
+
+def _as_non_negative_array(values) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    return np.maximum(np.nan_to_num(values, nan=0.0), 0.0)
+
+
+def allocate_reported_education_grants(
+    reported_grants, grant_capacities: dict[str, np.ndarray]
+) -> dict[str, np.ndarray]:
+    """Split aggregate FRS education grants across modelled grant capacity.
+
+    The FRS reports several direct education grants in one aggregate field. When
+    several modelled grants are plausible for the same person, allocate the
+    reported amount proportionally to each grant's modelled capacity and keep any
+    excess in the generic ``education_grants`` residual.
+    """
+
+    reported_grants = _as_non_negative_array(reported_grants)
+    capacities = {
+        variable: _as_non_negative_array(capacity)
+        for variable, capacity in grant_capacities.items()
+    }
+    total_capacity = np.zeros_like(reported_grants, dtype=float)
+    for variable, capacity in capacities.items():
+        if capacity.shape != reported_grants.shape:
+            raise ValueError(
+                f"{variable} capacity has shape {capacity.shape}, "
+                f"expected {reported_grants.shape}."
+            )
+        total_capacity += capacity
+
+    allocation_fraction = np.divide(
+        reported_grants,
+        total_capacity,
+        out=np.zeros_like(reported_grants, dtype=float),
+        where=total_capacity > 0,
+    )
+    allocation_fraction = np.minimum(allocation_fraction, 1)
+
+    allocations = {}
+    allocated_total = np.zeros_like(reported_grants, dtype=float)
+    for variable, capacity in capacities.items():
+        allocation = capacity * allocation_fraction
+        allocations[variable] = allocation
+        allocated_total += allocation
+
+    allocations["education_grants"] = np.maximum(reported_grants - allocated_total, 0)
+    return allocations
+
+
+def calculate_disabled_students_allowance_reported_grant_capacity(
+    sim, year: int, maximum: float
+) -> np.ndarray:
+    eligible = None
+    for variable in DISABLED_STUDENTS_ALLOWANCE_ELIGIBILITY_VARIABLES:
+        variable_eligible = np.asarray(sim.calculate(variable, year), dtype=bool)
+        eligible = (
+            variable_eligible if eligible is None else eligible & variable_eligible
+        )
+    equivalent_support = np.asarray(
+        sim.calculate("disabled_students_allowance_receives_equivalent_support", year),
+        dtype=bool,
+    )
+    return np.where(eligible & ~equivalent_support, float(maximum), 0.0)
+
+
+def split_reported_education_grants(
+    pe_person: pd.DataFrame, sim, year: int, dsa_maximum: float
+) -> pd.DataFrame:
+    """Move specific modelled grants out of the generic education-grant residual."""
+
+    grant_capacities = {
+        variable: sim.calculate(variable, year)
+        for variable in REPORTED_EDUCATION_GRANT_VARIABLES
+    }
+    grant_capacities[DISABLED_STUDENTS_ALLOWANCE_EXPENSE_INPUT] = (
+        calculate_disabled_students_allowance_reported_grant_capacity(
+            sim, year, dsa_maximum
+        )
+    )
+    allocations = allocate_reported_education_grants(
+        pe_person["education_grants"], grant_capacities
+    )
+
+    pe_person["education_grants"] = allocations["education_grants"]
+    pe_person[DISABLED_STUDENTS_ALLOWANCE_EXPENSE_INPUT] = allocations[
+        DISABLED_STUDENTS_ALLOWANCE_EXPENSE_INPUT
+    ]
+
+    return pe_person
 
 
 def create_frs(
@@ -1005,6 +1109,21 @@ def create_frs(
     pe_person = attach_legacy_benefit_proxies_from_frs_person(
         pe_person, person, sim, year
     )
+
+    if (pe_person["education_grants"] > 0).any():
+        student_support_dataset = UKSingleYearDataset(
+            person=pe_person,
+            benunit=pe_benunit,
+            household=pe_household,
+            fiscal_year=year,
+        )
+        student_support_sim = Microsimulation(dataset=student_support_dataset)
+        dsa_maximum = student_support_sim.tax_benefit_system.parameters(
+            year
+        ).gov.dfe.disabled_students_allowance.maximum
+        pe_person = split_reported_education_grants(
+            pe_person, student_support_sim, year, dsa_maximum
+        )
 
     # Generate stochastic take-up decisions
     # All randomness is generated here in the data package using take-up rates

--- a/policyengine_uk_data/datasets/frs.py
+++ b/policyengine_uk_data/datasets/frs.py
@@ -35,7 +35,7 @@ ESA_HEALTH_EMPLOYMENT_STATUSES = (
     EmploymentStatus.LONG_TERM_DISABLED.name,
     EmploymentStatus.SHORT_TERM_DISABLED.name,
 )
-REPORTED_EDUCATION_GRANT_VARIABLES = (
+FORMULA_MODELED_EDUCATION_GRANT_VARIABLES = (
     "childcare_grant",
     "parents_learning_allowance",
     "adult_dependants_grant",
@@ -43,6 +43,7 @@ REPORTED_EDUCATION_GRANT_VARIABLES = (
 DISABLED_STUDENTS_ALLOWANCE_EXPENSE_INPUT = (
     "disabled_students_allowance_eligible_expenses"
 )
+DISABLED_STUDENTS_ALLOWANCE_FIRST_MODELED_YEAR = 2025
 DISABLED_STUDENTS_ALLOWANCE_ELIGIBILITY_VARIABLES = (
     "maintenance_loan_in_england_system",
     "disabled_students_allowance_course_eligible",
@@ -279,6 +280,16 @@ def allocate_reported_education_grants(
 def calculate_disabled_students_allowance_reported_grant_capacity(
     sim, year: int, maximum: float
 ) -> np.ndarray:
+    if year < DISABLED_STUDENTS_ALLOWANCE_FIRST_MODELED_YEAR:
+        return np.zeros_like(
+            np.asarray(
+                sim.calculate(
+                    DISABLED_STUDENTS_ALLOWANCE_ELIGIBILITY_VARIABLES[0], year
+                )
+            ),
+            dtype=float,
+        )
+
     eligible = None
     for variable in DISABLED_STUDENTS_ALLOWANCE_ELIGIBILITY_VARIABLES:
         variable_eligible = np.asarray(sim.calculate(variable, year), dtype=bool)
@@ -295,11 +306,18 @@ def calculate_disabled_students_allowance_reported_grant_capacity(
 def split_reported_education_grants(
     pe_person: pd.DataFrame, sim, year: int, dsa_maximum: float
 ) -> pd.DataFrame:
-    """Move specific modelled grants out of the generic education-grant residual."""
+    """Move specific modelled grants out of the generic education-grant residual.
+
+    PLA, ADG, and Childcare Grant remain formula-driven because they are
+    calibration targets. Their modelled capacity is only used to avoid also
+    counting the same reported FRS grant amount in the generic residual.
+    DSA lacks a modelled amount signal, so its allocation seeds eligible
+    expenses directly where the DSA parameter is available.
+    """
 
     grant_capacities = {
         variable: sim.calculate(variable, year)
-        for variable in REPORTED_EDUCATION_GRANT_VARIABLES
+        for variable in FORMULA_MODELED_EDUCATION_GRANT_VARIABLES
     }
     grant_capacities[DISABLED_STUDENTS_ALLOWANCE_EXPENSE_INPUT] = (
         calculate_disabled_students_allowance_reported_grant_capacity(

--- a/policyengine_uk_data/tests/test_education_grants_split.py
+++ b/policyengine_uk_data/tests/test_education_grants_split.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+
+from policyengine_uk_data.datasets.frs import (
+    allocate_reported_education_grants,
+    split_reported_education_grants,
+)
+
+
+def test_allocate_reported_education_grants_splits_by_capacity():
+    allocations = allocate_reported_education_grants(
+        reported_grants=np.array([50, 300, 1_000, 100]),
+        grant_capacities={
+            "grant_a": np.array([100, 100, 100, 0]),
+            "grant_b": np.array([100, 0, 100, 0]),
+        },
+    )
+
+    np.testing.assert_allclose(allocations["grant_a"], [25, 100, 100, 0])
+    np.testing.assert_allclose(allocations["grant_b"], [25, 0, 100, 0])
+    np.testing.assert_allclose(allocations["education_grants"], [0, 200, 800, 100])
+
+
+class FakeStudentSupportSim:
+    def __init__(self, values):
+        self.values = values
+
+    def calculate(self, variable, year):
+        del year
+        return self.values[variable]
+
+
+def test_split_reported_education_grants_updates_residual_and_dsa_expenses():
+    pe_person = pd.DataFrame({"education_grants": [900, 1_200, 100]})
+    sim = FakeStudentSupportSim(
+        {
+            "childcare_grant": np.array([300, 0, 0]),
+            "parents_learning_allowance": np.array([600, 400, 0]),
+            "adult_dependants_grant": np.array([0, 600, 0]),
+            "maintenance_loan_in_england_system": np.array([False, False, True]),
+            "disabled_students_allowance_course_eligible": np.array(
+                [False, False, True]
+            ),
+            "disabled_students_allowance_has_qualifying_condition": np.array(
+                [False, False, True]
+            ),
+            "disabled_students_allowance_receives_equivalent_support": np.array(
+                [False, False, False]
+            ),
+        }
+    )
+
+    result = split_reported_education_grants(pe_person, sim, 2025, dsa_maximum=500)
+
+    assert "childcare_grant" not in result.columns
+    assert "parents_learning_allowance" not in result.columns
+    assert "adult_dependants_grant" not in result.columns
+    np.testing.assert_allclose(
+        result["disabled_students_allowance_eligible_expenses"], [0, 0, 100]
+    )
+    np.testing.assert_allclose(result["education_grants"], [0, 200, 0])

--- a/policyengine_uk_data/tests/test_education_grants_split.py
+++ b/policyengine_uk_data/tests/test_education_grants_split.py
@@ -59,3 +59,22 @@ def test_split_reported_education_grants_updates_residual_and_dsa_expenses():
         result["disabled_students_allowance_eligible_expenses"], [0, 0, 100]
     )
     np.testing.assert_allclose(result["education_grants"], [0, 200, 0])
+
+
+def test_split_reported_education_grants_does_not_seed_dsa_before_model_year():
+    pe_person = pd.DataFrame({"education_grants": [100]})
+    sim = FakeStudentSupportSim(
+        {
+            "childcare_grant": np.array([0]),
+            "parents_learning_allowance": np.array([0]),
+            "adult_dependants_grant": np.array([0]),
+            "maintenance_loan_in_england_system": np.array([True]),
+        }
+    )
+
+    result = split_reported_education_grants(pe_person, sim, 2024, dsa_maximum=500)
+
+    np.testing.assert_allclose(
+        result["disabled_students_allowance_eligible_expenses"], [0]
+    )
+    np.testing.assert_allclose(result["education_grants"], [100])

--- a/policyengine_uk_data/tests/test_legacy_benefit_proxies.py
+++ b/policyengine_uk_data/tests/test_legacy_benefit_proxies.py
@@ -232,6 +232,17 @@ class FakeMicrosimulation:
                             "FakeGov",
                             (),
                             {
+                                "dfe": type(
+                                    "FakeDfe",
+                                    (),
+                                    {
+                                        "disabled_students_allowance": type(
+                                            "FakeDsa",
+                                            (),
+                                            {"maximum": 27_783},
+                                        )()
+                                    },
+                                )(),
                                 "dwp": type(
                                     "FakeDwp",
                                     (),
@@ -259,7 +270,7 @@ class FakeMicrosimulation:
                                             },
                                         )(),
                                     },
-                                )()
+                                )(),
                             },
                         )()
                     },
@@ -274,6 +285,16 @@ class FakeMicrosimulation:
             return np.array([100])
         if variable == "state_pension_age":
             return pd.Series([66])
+        if variable in (
+            "childcare_grant",
+            "parents_learning_allowance",
+            "adult_dependants_grant",
+            "disabled_students_allowance_receives_equivalent_support",
+            "maintenance_loan_in_england_system",
+            "disabled_students_allowance_course_eligible",
+            "disabled_students_allowance_has_qualifying_condition",
+        ):
+            return np.zeros(len(self.dataset.person))
         raise KeyError(variable)
 
 
@@ -365,7 +386,7 @@ def test_create_frs_smoke_includes_legacy_proxy_columns(tmp_path, monkeypatch):
                 "pareamt": 0,
                 "allpay3": 0,
                 "allpay4": 0,
-                "grtdir1": 0,
+                "grtdir1": 100,
                 "grtdir2": 0,
             }
         ]
@@ -445,3 +466,5 @@ def test_create_frs_smoke_includes_legacy_proxy_columns(tmp_path, monkeypatch):
         "esa_health_condition_proxy",
         "esa_support_group_proxy",
     }.issubset(dataset.person.columns)
+    assert dataset.person["education_grants"].iloc[0] == 100
+    assert dataset.person["disabled_students_allowance_eligible_expenses"].iloc[0] == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "policyengine",
     "google-cloud-storage",
     "google-auth",
-    "policyengine-uk>=2.85.0",
+    "policyengine-uk>=2.86.0",
     "microcalibrate>=0.18.0",
     "microimpute>=1.0.1",
     "ruff>=0.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1351,7 +1351,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.85.0"
+version = "2.86.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -1359,14 +1359,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "tables" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/3d/ad2c4f0f702c9027f9b0b90db0226c3c03cc2f30a2a360e6be0de3babd46/policyengine_uk-2.85.0.tar.gz", hash = "sha256:8619045b2005dd80ffbe5f1ab29acd4151cb149de7b307ae4167df8d10cc7338", size = 1155602, upload-time = "2026-04-15T03:21:30.941Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/27/64dbdf03de42d8ae2a576024ba566a800e0e320350ade118dbd7275f2bca/policyengine_uk-2.86.0.tar.gz", hash = "sha256:955a99dbc962607173eed3442ef459c13b24c34bf0a4ae88a42ded41b1289cca", size = 1157557, upload-time = "2026-04-15T03:54:32.39Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/7f/45b29a916a67a77d045407a1e9d0c73bde2b6afe005bbe286d2c107afa9f/policyengine_uk-2.85.0-py3-none-any.whl", hash = "sha256:9c76893051529d45c2cbae49a1f8c46e81aae8464bb00b56a06b2ef56fc2c3b4", size = 1836001, upload-time = "2026-04-15T03:21:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/5c/91ba805a80c7932013d54adcd9e444d3d136cb2b650c9320077d6efbadc8/policyengine_uk-2.86.0-py3-none-any.whl", hash = "sha256:0ecf117eea68eadaab24dde712e7025a71f0a9a6e5a7b06a347444d51b1fa1c8", size = 1842731, upload-time = "2026-04-15T03:54:30.3Z" },
 ]
 
 [[package]]
 name = "policyengine-uk-data"
-version = "1.49.0"
+version = "1.50.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },
@@ -1421,7 +1421,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "policyengine" },
     { name = "policyengine-core", specifier = ">=3.19.4" },
-    { name = "policyengine-uk", specifier = ">=2.85.0" },
+    { name = "policyengine-uk", specifier = ">=2.86.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary
- Split aggregate FRS `education_grants` against modelled specific student-finance grant capacity.
- Keep generic `education_grants` as the residual instead of direct-overriding PLA, ADG, or Childcare Grant outputs, so calibration targets still use those programme formulas.
- Seed Disabled Students Allowance through `disabled_students_allowance_eligible_expenses` where reported grants plausibly identify DSA.
- Bump `policyengine-uk` to `>=2.86.0` for the DSA variables.

Closes #341.

## Aggregate sanity check
Applied in memory to local `frs_2025_calibrated_v3.h5`; this is not a full rebuild.

| Variable | Spend before | Spend after | Change | Recipients before | Recipients after | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `education_grants` | £1,644,949,163 | £1,642,785,841 | -£2,163,322 | 315,220 | 314,281 | -939 |
| `childcare_grant` | £0 | £0 | £0 | 0 | 0 | 0 |
| `parents_learning_allowance` | £17,166,249 | £17,166,249 | £0 | 8,481 | 8,481 | 0 |
| `adult_dependants_grant` | £6,883,249 | £6,883,249 | £0 | 1,942 | 1,942 | 0 |
| `disabled_students_allowance` | £0 | £1,051,251 | +£1,051,251 | 0 | 639 | +639 |

## Validation
- `uv run --python 3.13 ruff check policyengine_uk_data/datasets/frs.py policyengine_uk_data/tests/test_education_grants_split.py`
- `uv run --python 3.13 ruff format --check policyengine_uk_data/datasets/frs.py policyengine_uk_data/tests/test_education_grants_split.py`
- `uv run --python 3.13 pytest -q policyengine_uk_data/tests/test_education_grants_split.py policyengine_uk_data/tests/test_legacy_benefit_proxies.py`