### PR TITLE
Assign is_parent from FRS microdata

### DIFF
--- a/changelog.d/73.md
+++ b/changelog.d/73.md
@@ -1,0 +1,1 @@
+Assign `is_parent` from FRS adult-table membership and benefit-unit dependent-child counts (#73).

--- a/policyengine_uk_data/datasets/frs.py
+++ b/policyengine_uk_data/datasets/frs.py
@@ -228,6 +228,36 @@ def attach_legacy_benefit_proxies_from_frs_person(
     )
 
 
+def derive_is_parent_from_frs_microdata(
+    person_ids,
+    person_benunit_ids,
+    adult_person_ids,
+    benunit_ids,
+    dependent_children,
+) -> np.ndarray:
+    """Identify FRS adults in benefit units with dependent children.
+
+    FRS benefit units contain either one adult or a couple plus any dependent
+    children. Using the raw adult table and benefit-unit dependent-child count
+    avoids ranking adults across the whole household when multiple benefit
+    units share a household.
+    """
+
+    dependent_children_by_benunit = pd.Series(
+        np.asarray(dependent_children, dtype=float),
+        index=np.asarray(benunit_ids),
+    )
+    has_dependent_children = (
+        pd.Series(np.asarray(person_benunit_ids))
+        .map(dependent_children_by_benunit)
+        .fillna(0)
+        .to_numpy()
+        > 0
+    )
+    is_adult_record = np.isin(np.asarray(person_ids), np.asarray(adult_person_ids))
+    return is_adult_record & has_dependent_children
+
+
 def _as_non_negative_array(values) -> np.ndarray:
     values = np.asarray(values, dtype=float)
     return np.maximum(np.nan_to_num(values, nan=0.0), 0.0)
@@ -443,6 +473,23 @@ def create_frs(
     pe_person["hours_worked"] = np.maximum(person.tothours, 0) * 52
     pe_person["is_household_head"] = person.hrpid == 1
     pe_person["is_benunit_head"] = person.uperson == 1
+    dependent_children = (
+        benunit.depchldb
+        if "depchldb" in benunit
+        else frs["child"]
+        .groupby("benunit_id")
+        .size()
+        .reindex(benunit.benunit_id)
+        .fillna(0)
+        .to_numpy()
+    )
+    pe_person["is_parent"] = derive_is_parent_from_frs_microdata(
+        person_ids=pe_person.person_id,
+        person_benunit_ids=pe_person.person_benunit_id,
+        adult_person_ids=frs["adult"].person_id,
+        benunit_ids=pe_benunit.benunit_id,
+        dependent_children=dependent_children,
+    )
     MARITAL = [
         "MARRIED",
         "SINGLE",

--- a/policyengine_uk_data/tests/test_is_parent_from_frs.py
+++ b/policyengine_uk_data/tests/test_is_parent_from_frs.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from policyengine_uk_data.datasets.frs import derive_is_parent_from_frs_microdata
+
+
+def test_is_parent_uses_benefit_unit_not_household_rank():
+    result = derive_is_parent_from_frs_microdata(
+        person_ids=np.array([1_001, 1_002, 1_003, 1_004]),
+        person_benunit_ids=np.array([101, 101, 102, 102]),
+        adult_person_ids=np.array([1_001, 1_002, 1_003]),
+        benunit_ids=np.array([101, 102]),
+        dependent_children=np.array([0, 1]),
+    )
+
+    assert result.tolist() == [False, False, True, False]
+
+
+def test_is_parent_marks_both_adults_in_couple_with_children():
+    result = derive_is_parent_from_frs_microdata(
+        person_ids=np.array([2_001, 2_002, 2_003]),
+        person_benunit_ids=np.array([201, 201, 201]),
+        adult_person_ids=np.array([2_001, 2_002]),
+        benunit_ids=np.array([201]),
+        dependent_children=np.array([1]),
+    )
+
+    assert result.tolist() == [True, True, False]

--- a/policyengine_uk_data/tests/test_legacy_benefit_proxies.py
+++ b/policyengine_uk_data/tests/test_legacy_benefit_proxies.py
@@ -465,6 +465,8 @@ def test_create_frs_smoke_includes_legacy_proxy_columns(tmp_path, monkeypatch):
         "legacy_jobseeker_proxy",
         "esa_health_condition_proxy",
         "esa_support_group_proxy",
+        "is_parent",
     }.issubset(dataset.person.columns)
+    assert not dataset.person["is_parent"].iloc[0]
     assert dataset.person["education_grants"].iloc[0] == 100
     assert dataset.person["disabled_students_allowance_eligible_expenses"].iloc[0] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk-data"
-version = "1.50.0"
+version = "1.50.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },


### PR DESCRIPTION
## Summary
- Assign `is_parent` directly from FRS adult-table membership plus benefit-unit dependent-child counts.
- Avoid ranking adults across a whole household when multiple benefit units share one household.
- Add focused helper tests and extend the FRS smoke test to assert the column is produced.
- Sync the editable package version in `uv.lock` with `pyproject.toml`.

Closes #73.

## Impact check
Using local raw FRS microdata and approximating the old formula:

| Dataset | Persons | New FRS parents | Old formula parents | Differing persons | New true / old false | Old true / new false | Diffs in multi-BU households |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| frs_2022_23 | 53,577 | 10,901 | 10,396 | 561 | 533 | 28 | 299 |
| frs_2023_24 | 36,248 | 7,429 | 7,119 | 352 | 331 | 21 | 206 |

## Validation
- `uv run --python 3.13 ruff check policyengine_uk_data/datasets/frs.py policyengine_uk_data/tests/test_is_parent_from_frs.py policyengine_uk_data/tests/test_legacy_benefit_proxies.py`
- `uv run --python 3.13 ruff format --check policyengine_uk_data/datasets/frs.py policyengine_uk_data/tests/test_is_parent_from_frs.py policyengine_uk_data/tests/test_legacy_benefit_proxies.py`
- `uv run --python 3.13 pytest -q policyengine_uk_data/tests/test_is_parent_from_frs.py policyengine_uk_data/tests/test_legacy_benefit_proxies.py`
