### PR TITLE
Reduce OA clones in GitHub Actions builds

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -33,6 +33,7 @@ jobs:
     env:
       HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
       PYTHONUNBUFFERED: "1"
+      PE_UK_DATA_OA_CLONES: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -36,6 +36,7 @@ jobs:
     env:
       HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
       PYTHONUNBUFFERED: "1"
+      PE_UK_DATA_OA_CLONES: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/changelog.d/fix-publication.fixed.md
+++ b/changelog.d/fix-publication.fixed.md
@@ -1,0 +1,1 @@
+Reduce OA cloning in GitHub Actions dataset builds so publication completes on hosted runners.

--- a/policyengine_uk_data/datasets/create_datasets.py
+++ b/policyengine_uk_data/datasets/create_datasets.py
@@ -8,6 +8,22 @@ from policyengine_uk_data.utils.build_environment import (
 logging.basicConfig(level=logging.INFO)
 
 
+def _get_positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {raw_value!r}.") from exc
+
+    if value < 1:
+        raise ValueError(f"{name} must be >= 1, got {value}.")
+
+    return value
+
+
 def main():
     """Create enhanced FRS dataset with rich progress tracking."""
     try:
@@ -27,6 +43,10 @@ def main():
         # Use reduced epochs and fidelity for testing
         is_testing = os.environ.get("TESTING", "0") == "1"
         epochs = 32 if is_testing else 512
+        oa_clones = _get_positive_int_env(
+            "PE_UK_DATA_OA_CLONES",
+            2 if is_testing else 10,
+        )
 
         progress_tracker = ProcessingProgress()
 
@@ -118,8 +138,7 @@ def main():
                 clone_and_assign,
             )
 
-            n_clones = 2 if is_testing else 10
-            frs = clone_and_assign(frs, n_clones=n_clones)
+            frs = clone_and_assign(frs, n_clones=oa_clones)
             update_dataset("Clone and assign OA geography", "completed")
 
             # Uprate dataset


### PR DESCRIPTION
## Summary
- parameterize the OA clone count in dataset creation via `PE_UK_DATA_OA_CLONES`
- set GitHub Actions dataset builds to use a single OA assignment per household
- add a changelog fragment for the publication fix

## Why
Recent `Push` publication runs on `main` have been dying inside `make data` during constituency calibration, before `Upload data` starts. The regression lines up with the OA calibration pipeline landing and the default build path cloning each household 10x before calibration.

This keeps the OA assignment path available while making the hosted-runner build fit again.

## Validation
- `python -m compileall policyengine_uk_data/datasets/create_datasets.py`
- `PYTHONPATH=/Users/maxghenis/policyengine-uk uv run --python 3.13 --with ".[dev]" pytest policyengine_uk_data/tests/test_clone_and_assign.py -q`
- `PYTHONPATH=/Users/maxghenis/policyengine-uk uv run --python 3.13 --with ".[dev]" pytest policyengine_uk_data/tests/test_build_environment.py -q`