### PR TITLE
Set Marriage Allowance take-up rate to HMRC outturn (#368)

### DIFF
--- a/changelog.d/368.md
+++ b/changelog.d/368.md
@@ -1,0 +1,1 @@
+- Set Marriage Allowance take-up rate to 0.5 (HMRC outturn ~2.1m claimants of ~4.2m eligible couples) instead of the placeholder 1.0, so microsimulation no longer overstates Marriage Allowance cost by ~£500m/year.

--- a/policyengine_uk_data/parameters/take_up/marriage_allowance.yaml
+++ b/policyengine_uk_data/parameters/take_up/marriage_allowance.yaml
@@ -1,6 +1,9 @@
-description: Percentage of eligible couples who claim Marriage Allowance.
+description: Share of eligible couples who claim Marriage Allowance. HMRC outturn shows ~2.1m claimants vs ~4.2m eligible (~50% take-up). Read by `datasets/frs.py` to populate `would_claim_marriage_allowance` stochastically per person.
 metadata:
   unit: /1
   label: Marriage Allowance take-up rate
+  reference:
+    - title: House of Commons Library — Income tax allowances for married couples (SN00870)
+      href: https://commonslibrary.parliament.uk/research-briefings/sn00870/
 values:
-  2000-01-01: 1
+  2000-01-01: 0.5


### PR DESCRIPTION
## Summary
- Closes #368.
- Update [`policyengine_uk_data/parameters/take_up/marriage_allowance.yaml`](policyengine_uk_data/parameters/take_up/marriage_allowance.yaml) from `1.0` to `0.5`, matching [HMRC outturn (~2.1m claimants of ~4.2m eligible couples)](https://commonslibrary.parliament.uk/research-briefings/sn00870/).
- Adds House of Commons Library reference and a description note that the file is read by `datasets/frs.py` to populate `would_claim_marriage_allowance` stochastically.

## Why this matters

This file is the load-bearing one for microsimulation. With take-up at 1.0, the model overstates Marriage Allowance cost by ~£500m/year (model implies ~£1.06bn vs HMRC outturn ~£580m). At 0.5 it lines up with published outturn.

Companion change in `policyengine-uk`: PolicyEngine/policyengine-uk#1636 — the documentation parameter on the model side. Source issue: PolicyEngine/policyengine-uk#623.

## Test plan
- [ ] FRS build run to confirm `would_claim_marriage_allowance` rate halves.
- [ ] Sanity check Marriage Allowance aggregate microsim cost against £580m HMRC outturn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)