### PR TITLE
Calibrate combined self-employed NICs and skip inert Class 3 target

### DIFF
--- a/changelog.d/378.md
+++ b/changelog.d/378.md
@@ -1,0 +1,1 @@
+- Calibrate against self-employed NICs (combined OBR Class 2 + Class 4 line) and skip the inert Class 3 target so calibration diagnostics are no longer misleading (#378, partial close of #88).

--- a/policyengine_uk_data/targets/sources/obr.py
+++ b/policyengine_uk_data/targets/sources/obr.py
@@ -249,6 +249,21 @@ def _parse_nics(wb: openpyxl.Workbook) -> list[Target]:
             ["Class 1 Employer NICs"],
             "ni_employer",
         ),
+        # Self-employed NICs.
+        #
+        # Recent OBR EFOs (e.g. March 2026) publish a single combined
+        # "Class 4 and Class 2 Self employed NICs" line rather than two
+        # separate rows. Earlier EFOs split them. We list the combined
+        # label first; if a future EFO reverts to separate rows, the
+        # legacy ``ni_class_2`` / ``ni_class_4`` entries below will pick
+        # them up instead.
+        "ni_self_employed": (
+            [
+                "Class 4 and Class 2 Self employed NICs",
+                "Class 2 and Class 4 Self employed NICs",
+            ],
+            "ni_self_employed",
+        ),
         "ni_class_2": (
             [
                 "Class 2 NICs",
@@ -257,14 +272,14 @@ def _parse_nics(wb: openpyxl.Workbook) -> list[Target]:
             ],
             "ni_class_2",
         ),
-        "ni_class_3": (
-            [
-                "Class 3 NICs",
-                "Class 3 Voluntary NICs",
-                "Class 3 voluntary NICs",
-            ],
-            "ni_class_3",
-        ),
+        # Class 3 NICs are voluntary contributions to fill state-pension
+        # record gaps. The PE-UK variable ni_class_3 is an input with no
+        # formula and no dataset path populates it, so a calibration target
+        # would fall through to a flat-zero matrix column with no signal —
+        # see issue #378. Class 3 is also small (~£50m vs ~£150bn total
+        # NICs, ~0.03%), so the calibrator cannot meaningfully match it
+        # without a record-level imputation. Skipped here pending an
+        # imputation that addresses #88; restore the row when one lands.
         "ni_class_4": (
             [
                 "Class 4 NICs",
@@ -296,20 +311,38 @@ def _parse_nics(wb: openpyxl.Workbook) -> list[Target]:
             continue
 
         values = _read_row_values(ws, row_num, cols)
-        if values:
-            targets.append(
-                Target(
-                    name=f"obr/{name}",
-                    variable=variable,
-                    source="obr",
-                    unit=Unit.GBP,
-                    values=values,
-                    reference_url=ref,
-                    forecast_vintage=vintage,
-                )
-            )
+        if not values:
+            continue
+
+        kwargs: dict = {
+            "name": f"obr/{name}",
+            "variable": variable,
+            "source": "obr",
+            "unit": Unit.GBP,
+            "values": values,
+            "reference_url": ref,
+            "forecast_vintage": vintage,
+        }
+        # The combined self-employed total has no PE-UK variable of its
+        # own; sum the two underlying classes via custom_compute so the
+        # target hits a meaningful matrix column.
+        if name == "ni_self_employed":
+            kwargs["custom_compute"] = _compute_ni_self_employed_combined
+
+        targets.append(Target(**kwargs))
 
     return targets
+
+
+def _compute_ni_self_employed_combined(ctx, target, year):  # noqa: ARG001
+    """Sum Class 2 and Class 4 NICs at the household level.
+
+    Used as the ``custom_compute`` for the combined OBR target whenever
+    the EFO publishes Class 2 + Class 4 as a single self-employed line.
+    """
+    class_2 = ctx.sim.calculate("ni_class_2")
+    class_4 = ctx.sim.calculate("ni_class_4")
+    return ctx.household_from_person(class_2 + class_4)
 
 
 def _parse_welfare(wb: openpyxl.Workbook) -> list[Target]:

--- a/policyengine_uk_data/targets/sources/obr.py
+++ b/policyengine_uk_data/targets/sources/obr.py
@@ -323,26 +323,9 @@ def _parse_nics(wb: openpyxl.Workbook) -> list[Target]:
             "reference_url": ref,
             "forecast_vintage": vintage,
         }
-        # The combined self-employed total has no PE-UK variable of its
-        # own; sum the two underlying classes via custom_compute so the
-        # target hits a meaningful matrix column.
-        if name == "ni_self_employed":
-            kwargs["custom_compute"] = _compute_ni_self_employed_combined
-
         targets.append(Target(**kwargs))
 
     return targets
-
-
-def _compute_ni_self_employed_combined(ctx, target, year):  # noqa: ARG001
-    """Sum Class 2 and Class 4 NICs at the household level.
-
-    Used as the ``custom_compute`` for the combined OBR target whenever
-    the EFO publishes Class 2 + Class 4 as a single self-employed line.
-    """
-    class_2 = ctx.sim.calculate("ni_class_2")
-    class_4 = ctx.sim.calculate("ni_class_4")
-    return ctx.household_from_person(class_2 + class_4)
 
 
 def _parse_welfare(wb: openpyxl.Workbook) -> list[Target]:

--- a/policyengine_uk_data/tests/test_obr_nic_signal.py
+++ b/policyengine_uk_data/tests/test_obr_nic_signal.py
@@ -7,9 +7,8 @@ Active targets (against the March 2026 EFO format):
 
 - ``obr/ni_employee`` — Class 1 employee, formula-derived in PE-UK.
 - ``obr/ni_employer`` — Class 1 employer, formula-derived in PE-UK.
-- ``obr/ni_self_employed`` — combined Class 2 + Class 4, computed via
-  ``custom_compute`` since recent EFOs publish a single self-employed
-  line. Sums the two PE-UK variables at the household level.
+- ``obr/ni_self_employed`` — combined Class 2 + Class 4, aligned to the
+  PE-UK ``ni_self_employed`` variable.
 
 Class 3 is intentionally absent because no dataset populates
 ``ni_class_3`` — the matrix column would be a flat zero.
@@ -26,7 +25,6 @@ Two layers:
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
 
 
@@ -38,6 +36,7 @@ _ACTIVE_TOPLINE_TARGET_NAMES = (
 _PE_UK_NIC_VARIABLES_WITH_SIGNAL = (
     "ni_employee",
     "ni_employer",
+    "ni_self_employed",
     "ni_class_2",
     "ni_class_4",
 )
@@ -55,11 +54,9 @@ def test_obr_nic_target_registry_includes_active_classes():
     assert actual == expected, f"Missing OBR NIC targets: {expected - actual}"
 
 
-def test_obr_ni_self_employed_target_uses_custom_compute():
-    """The combined self-employed target is virtual — it must carry a
-    custom_compute callable, otherwise the loss matrix tries to look up a
-    non-existent ``ni_self_employed`` PE-UK variable and emits an empty
-    column."""
+def test_obr_ni_self_employed_target_uses_direct_pe_variable():
+    """The combined self-employed target must map directly to the PE-UK
+    ``ni_self_employed`` variable so target lineage stays explicit."""
     from policyengine_uk_data.targets import get_all_targets
 
     target = next(
@@ -67,9 +64,8 @@ def test_obr_ni_self_employed_target_uses_custom_compute():
         None,
     )
     assert target is not None, "obr/ni_self_employed not registered"
-    assert callable(target.custom_compute), (
-        "obr/ni_self_employed must carry a custom_compute (sum of class 2 + 4)"
-    )
+    assert target.variable == "ni_self_employed"
+    assert target.custom_compute is None
 
 
 def test_obr_ni_class_3_target_is_intentionally_absent():
@@ -100,24 +96,6 @@ def test_active_nic_variable_has_nonzero_variation(enhanced_frs, variable):
     assert float(values.var()) > 0.0, (
         f"{variable}: zero variance — calibration cannot move it"
     )
-
-
-def test_self_employed_combined_compute_returns_nonzero(enhanced_frs):
-    """``_compute_ni_self_employed_combined`` must return a non-zero
-    household-level vector — i.e. the sum of Class 2 and Class 4 actually
-    has signal in the dataset, not just each component individually."""
-    from policyengine_uk import Microsimulation
-
-    sim = Microsimulation(dataset=enhanced_frs)
-    sim.default_calculation_period = enhanced_frs.time_period
-
-    combined_person = (
-        sim.calculate("ni_class_2").values + sim.calculate("ni_class_4").values
-    )
-    combined_household = sim.map_result(combined_person, "person", "household")
-
-    assert (combined_household != 0).sum() > 0
-    assert float(np.asarray(combined_household).var()) > 0.0
 
 
 def test_ni_class_3_simulator_returns_uniform_zero(enhanced_frs):

--- a/policyengine_uk_data/tests/test_obr_nic_signal.py
+++ b/policyengine_uk_data/tests/test_obr_nic_signal.py
@@ -1,0 +1,138 @@
+"""Regression tests for OBR NIC calibration signal.
+
+Issue #378 (closing) and partial close of #88: every active OBR NIC
+target must produce a non-trivial calibration matrix column.
+
+Active targets (against the March 2026 EFO format):
+
+- ``obr/ni_employee`` — Class 1 employee, formula-derived in PE-UK.
+- ``obr/ni_employer`` — Class 1 employer, formula-derived in PE-UK.
+- ``obr/ni_self_employed`` — combined Class 2 + Class 4, computed via
+  ``custom_compute`` since recent EFOs publish a single self-employed
+  line. Sums the two PE-UK variables at the household level.
+
+Class 3 is intentionally absent because no dataset populates
+``ni_class_3`` — the matrix column would be a flat zero.
+
+Two layers:
+
+1. Registry layer (no Microsimulation) — assert the three expected NIC
+   targets are present in the OBR target set and Class 3 is absent.
+2. Signal layer (gated on the enhanced FRS fixture) — assert each
+   active NIC variable produces non-zero variation across households,
+   and that Class 3 would not. Catches future regressions where someone
+   re-adds the target without an accompanying imputation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+_ACTIVE_TOPLINE_TARGET_NAMES = (
+    "obr/ni_employee",
+    "obr/ni_employer",
+    "obr/ni_self_employed",
+)
+_PE_UK_NIC_VARIABLES_WITH_SIGNAL = (
+    "ni_employee",
+    "ni_employer",
+    "ni_class_2",
+    "ni_class_4",
+)
+
+
+# ── Layer 1: registry contract ──────────────────────────────────────
+
+
+def test_obr_nic_target_registry_includes_active_classes():
+    """The OBR target source must emit the three top-line NIC class targets."""
+    from policyengine_uk_data.targets import get_all_targets
+
+    expected = set(_ACTIVE_TOPLINE_TARGET_NAMES)
+    actual = {t.name for t in get_all_targets() if t.name in expected}
+    assert actual == expected, f"Missing OBR NIC targets: {expected - actual}"
+
+
+def test_obr_ni_self_employed_target_uses_custom_compute():
+    """The combined self-employed target is virtual — it must carry a
+    custom_compute callable, otherwise the loss matrix tries to look up a
+    non-existent ``ni_self_employed`` PE-UK variable and emits an empty
+    column."""
+    from policyengine_uk_data.targets import get_all_targets
+
+    target = next(
+        (t for t in get_all_targets() if t.name == "obr/ni_self_employed"),
+        None,
+    )
+    assert target is not None, "obr/ni_self_employed not registered"
+    assert callable(target.custom_compute), (
+        "obr/ni_self_employed must carry a custom_compute (sum of class 2 + 4)"
+    )
+
+
+def test_obr_ni_class_3_target_is_intentionally_absent():
+    """Class 3 must not appear in the registered targets (#378)."""
+    from policyengine_uk_data.targets import get_all_targets
+
+    obr_targets = [t for t in get_all_targets() if t.source == "obr"]
+    assert "obr/ni_class_3" not in {t.name for t in obr_targets}
+    assert "ni_class_3" not in {t.variable for t in obr_targets}
+
+
+# ── Layer 2: simulator signal ───────────────────────────────────────
+
+
+@pytest.mark.parametrize("variable", _PE_UK_NIC_VARIABLES_WITH_SIGNAL)
+def test_active_nic_variable_has_nonzero_variation(enhanced_frs, variable):
+    """Each active NIC variable must produce variation across households,
+    otherwise the calibration matrix column is a flat constant and the
+    optimiser cannot match its target."""
+    from policyengine_uk import Microsimulation
+
+    sim = Microsimulation(dataset=enhanced_frs)
+    sim.default_calculation_period = enhanced_frs.time_period
+    values = sim.calculate(variable).values
+
+    nonzero = int((values != 0).sum())
+    assert nonzero > 0, f"{variable}: all values are zero — calibration would be inert"
+    assert float(values.var()) > 0.0, (
+        f"{variable}: zero variance — calibration cannot move it"
+    )
+
+
+def test_self_employed_combined_compute_returns_nonzero(enhanced_frs):
+    """``_compute_ni_self_employed_combined`` must return a non-zero
+    household-level vector — i.e. the sum of Class 2 and Class 4 actually
+    has signal in the dataset, not just each component individually."""
+    from policyengine_uk import Microsimulation
+
+    sim = Microsimulation(dataset=enhanced_frs)
+    sim.default_calculation_period = enhanced_frs.time_period
+
+    combined_person = (
+        sim.calculate("ni_class_2").values + sim.calculate("ni_class_4").values
+    )
+    combined_household = sim.map_result(combined_person, "person", "household")
+
+    assert (combined_household != 0).sum() > 0
+    assert float(np.asarray(combined_household).var()) > 0.0
+
+
+def test_ni_class_3_simulator_returns_uniform_zero(enhanced_frs):
+    """Direct evidence for why Class 3 is excluded: the simulator produces
+    a flat-zero vector, so any calibration target on it is inert. If this
+    ever stops being true (e.g. policyengine-uk adds a formula or this
+    repo adds an imputation), the Class 3 target should be re-enabled in
+    obr.py and the corresponding skip removed."""
+    from policyengine_uk import Microsimulation
+
+    sim = Microsimulation(dataset=enhanced_frs)
+    sim.default_calculation_period = enhanced_frs.time_period
+    values = sim.calculate("ni_class_3").values
+
+    assert (values == 0).all(), (
+        f"ni_class_3 has {(values != 0).sum()} non-zero entries — "
+        "if intended, restore the target in obr.py and update this test."
+    )

--- a/policyengine_uk_data/tests/test_obr_nics.py
+++ b/policyengine_uk_data/tests/test_obr_nics.py
@@ -1,13 +1,24 @@
-"""Regression test for OBR NIC target parsing.
+"""Regression tests for OBR NIC target parsing.
 
-Bug-hunt finding U8: `_parse_nics` only covered Class 1 employee and
-employer NICs, omitting Classes 2 (self-employed flat-rate), 3 (voluntary)
-and 4 (self-employed profit-based). Calibration had no target for those
-receipts and pushed self-employment income downward to compensate.
+Bug-hunt finding U8: ``_parse_nics`` originally only covered Class 1
+employee and employer NICs, omitting Classes 2 (self-employed flat-rate),
+3 (voluntary) and 4 (self-employed profit-based). Calibration had no
+target for those receipts and pushed self-employment income downward to
+compensate.
 
-This test drives the parser with a minimal in-memory openpyxl workbook
-that mimics the OBR EFO Table 3.4 layout, and asserts that targets for
-all five NIC variables are produced.
+Follow-up (issue #378, partial close of #88):
+
+- **Class 3** is voluntary contributions paid by people topping up
+  their state-pension record. PolicyEngine UK exposes ``ni_class_3``
+  as an input variable, but no dataset builder, imputation, or utility
+  populates it — so a Class 3 target would be a flat-zero matrix
+  column with no signal. The parser therefore drops it.
+- **Classes 2 + 4** are bundled in recent OBR EFOs (e.g. March 2026)
+  as a single "Class 4 and Class 2 Self employed NICs" line. The
+  parser emits a combined ``obr/ni_self_employed`` target that uses
+  ``custom_compute`` to sum the two PE-UK variables. If a future EFO
+  reverts to separate rows, the legacy ``ni_class_2`` / ``ni_class_4``
+  candidates still match and emit individually.
 """
 
 from __future__ import annotations
@@ -22,104 +33,154 @@ if importlib.util.find_spec("openpyxl") is None:
 
 import openpyxl  # noqa: E402
 
+_FAKE_CONFIG = {
+    "obr": {
+        "vintage": "test",
+        "efo_receipts": "https://example.invalid/receipts",
+        "efo_expenditure": "https://example.invalid/expenditure",
+    }
+}
 
-def _build_fake_obr_workbook() -> openpyxl.Workbook:
-    """Create a stand-in for OBR EFO receipts with a minimal Table 3.4."""
+
+def _populate_sheet(ws, rows: list[tuple[str, list[float]]]) -> None:
+    """Write rows of (label, fy_values) into column B / C-I of ``ws``."""
+    for row_idx, (label, values) in enumerate(rows, start=2):
+        ws.cell(row=row_idx, column=2, value=label)
+        for col_idx, value in enumerate(values, start=3):
+            ws.cell(row=row_idx, column=col_idx, value=value)
+
+
+def _build_combined_efo_workbook() -> openpyxl.Workbook:
+    """Mimic the March 2026+ EFO Table 3.4 layout with combined SE NICs."""
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = "3.4"
-
-    # Column B holds row labels; columns C-I hold FY values in £bn.
-    rows = [
-        ("Class 1 Employee NICs", [120.0] * 7),
-        ("Class 1 Employer NICs", [140.0] * 7),
-        ("Class 2 NICs", [0.3] * 7),
-        ("Class 3 NICs", [0.05] * 7),
-        ("Class 4 NICs", [4.5] * 7),
-    ]
-    for row_idx, (label, values) in enumerate(rows, start=2):
-        ws.cell(row=row_idx, column=2, value=label)  # col B
-        for col_idx, value in enumerate(values, start=3):  # cols C-I
-            ws.cell(row=row_idx, column=col_idx, value=value)
-
+    _populate_sheet(
+        ws,
+        [
+            ("Class 1 Employee NICs", [120.0] * 7),
+            ("Class 1 Employer NICs", [140.0] * 7),
+            ("Class 4 and Class 2 Self employed NICs", [4.8] * 7),
+            # Class 3 is bundled into "Other NIC" in current EFOs and is
+            # not directly extractable; included here only to confirm the
+            # parser does not emit a Class 3 target.
+            ("Other NIC", [0.5] * 7),
+        ],
+    )
     return wb
 
 
-def test_parse_nics_covers_all_five_classes():
+def _build_separate_efo_workbook() -> openpyxl.Workbook:
+    """Mimic an older EFO layout with separate Class 2 / Class 4 rows."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "3.4"
+    _populate_sheet(
+        ws,
+        [
+            ("Class 1 Employee NICs", [120.0] * 7),
+            ("Class 1 Employer NICs", [140.0] * 7),
+            ("Class 2 NICs", [0.3] * 7),
+            ("Class 3 NICs", [0.05] * 7),
+            ("Class 4 NICs", [4.5] * 7),
+        ],
+    )
+    return wb
+
+
+def test_parse_nics_combined_self_employed_line():
+    """Current EFO format: combined Class 2+4 line gets a single target with
+    custom_compute, alongside Class 1 employee/employer."""
     from policyengine_uk_data.targets.sources import obr as obr_module
 
-    wb = _build_fake_obr_workbook()
+    with patch.object(obr_module, "load_config", return_value=_FAKE_CONFIG):
+        targets = obr_module._parse_nics(_build_combined_efo_workbook())
 
-    fake_config = {
-        "obr": {
-            "vintage": "test",
-            "efo_receipts": "https://example.invalid/receipts",
-            "efo_expenditure": "https://example.invalid/expenditure",
-        }
+    names = {t.name for t in targets}
+    assert names == {
+        "obr/ni_employee",
+        "obr/ni_employer",
+        "obr/ni_self_employed",
     }
-    with patch.object(obr_module, "load_config", return_value=fake_config):
-        targets = obr_module._parse_nics(wb)
+
+    combined = next(t for t in targets if t.name == "obr/ni_self_employed")
+    assert combined.variable == "ni_self_employed"
+    assert combined.values[2024] == pytest.approx(4.8e9)
+    # The combined target is virtual — it must carry a custom_compute that
+    # sums the two underlying PE-UK variables. Without it the loss matrix
+    # falls through to the simple-GBP path and looks for a non-existent
+    # `ni_self_employed` PE-UK variable.
+    assert callable(combined.custom_compute)
+
+
+def test_parse_nics_falls_back_to_separate_classes_for_old_efo():
+    """If a future EFO publishes Class 2 and Class 4 on separate rows again,
+    the legacy candidates pick them up individually."""
+    from policyengine_uk_data.targets.sources import obr as obr_module
+
+    with patch.object(obr_module, "load_config", return_value=_FAKE_CONFIG):
+        targets = obr_module._parse_nics(_build_separate_efo_workbook())
 
     names = {t.name for t in targets}
     assert names == {
         "obr/ni_employee",
         "obr/ni_employer",
         "obr/ni_class_2",
-        "obr/ni_class_3",
         "obr/ni_class_4",
     }
 
-    variables = {t.variable for t in targets}
-    # Variable names must match the policyengine-uk variable identifiers so
-    # calibration can map them to simulated totals.
-    assert variables == {
-        "ni_employee",
-        "ni_employer",
-        "ni_class_2",
-        "ni_class_3",
-        "ni_class_4",
-    }
-
-    # Values are scaled by 1e9 (£bn → £) inside _read_row_values.
     class_4_target = next(t for t in targets if t.variable == "ni_class_4")
     assert class_4_target.values[2024] == pytest.approx(4.5e9)
 
 
+def test_parse_nics_intentionally_skips_class_3_in_combined_efo():
+    """In the current combined-line layout, Class 3 is hidden inside
+    "Other NIC" and the parser must not emit it (#378)."""
+    from policyengine_uk_data.targets.sources import obr as obr_module
+
+    with patch.object(obr_module, "load_config", return_value=_FAKE_CONFIG):
+        targets = obr_module._parse_nics(_build_combined_efo_workbook())
+
+    assert "obr/ni_class_3" not in {t.name for t in targets}
+    assert "ni_class_3" not in {t.variable for t in targets}
+
+
+def test_parse_nics_intentionally_skips_class_3_in_separate_efo():
+    """Even when an EFO publishes a Class 3 row, the parser must not emit
+    a target for it — the underlying PE-UK variable has no signal (#378)."""
+    from policyengine_uk_data.targets.sources import obr as obr_module
+
+    with patch.object(obr_module, "load_config", return_value=_FAKE_CONFIG):
+        targets = obr_module._parse_nics(_build_separate_efo_workbook())
+
+    assert "obr/ni_class_3" not in {t.name for t in targets}
+    assert "ni_class_3" not in {t.variable for t in targets}
+
+
 def test_parse_nics_tolerates_alt_label_wording():
-    """The parser should accept common wording variants for self-employed rows."""
+    """Common wording variants (`Self-Employed` vs `self-employed`) match."""
     from policyengine_uk_data.targets.sources import obr as obr_module
 
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = "3.4"
+    _populate_sheet(
+        ws,
+        [
+            ("Class 1 Employee NICs", [100.0] * 7),
+            ("Class 1 Employer NICs", [110.0] * 7),
+            ("Class 2 Self-Employed NICs", [0.2] * 7),
+            ("Class 3 Voluntary NICs", [0.04] * 7),
+            ("Class 4 Self-Employed NICs", [4.0] * 7),
+        ],
+    )
 
-    # Use alternative labels that the parser should still find.
-    rows = [
-        ("Class 1 Employee NICs", [100.0] * 7),
-        ("Class 1 Employer NICs", [110.0] * 7),
-        ("Class 2 Self-Employed NICs", [0.2] * 7),
-        ("Class 3 Voluntary NICs", [0.04] * 7),
-        ("Class 4 Self-Employed NICs", [4.0] * 7),
-    ]
-    for row_idx, (label, values) in enumerate(rows, start=2):
-        ws.cell(row=row_idx, column=2, value=label)
-        for col_idx, value in enumerate(values, start=3):
-            ws.cell(row=row_idx, column=col_idx, value=value)
-
-    fake_config = {
-        "obr": {
-            "vintage": "test",
-            "efo_receipts": "https://example.invalid/receipts",
-            "efo_expenditure": "https://example.invalid/expenditure",
-        }
-    }
-    with patch.object(obr_module, "load_config", return_value=fake_config):
+    with patch.object(obr_module, "load_config", return_value=_FAKE_CONFIG):
         targets = obr_module._parse_nics(wb)
 
     assert {t.variable for t in targets} == {
         "ni_employee",
         "ni_employer",
         "ni_class_2",
-        "ni_class_3",
         "ni_class_4",
     }

--- a/policyengine_uk_data/tests/test_obr_nics.py
+++ b/policyengine_uk_data/tests/test_obr_nics.py
@@ -15,8 +15,8 @@ Follow-up (issue #378, partial close of #88):
   column with no signal. The parser therefore drops it.
 - **Classes 2 + 4** are bundled in recent OBR EFOs (e.g. March 2026)
   as a single "Class 4 and Class 2 Self employed NICs" line. The
-  parser emits a combined ``obr/ni_self_employed`` target that uses
-  ``custom_compute`` to sum the two PE-UK variables. If a future EFO
+  parser emits a combined ``obr/ni_self_employed`` target that maps
+  directly to the PE-UK ``ni_self_employed`` variable. If a future EFO
   reverts to separate rows, the legacy ``ni_class_2`` / ``ni_class_4``
   candidates still match and emit individually.
 """
@@ -89,8 +89,8 @@ def _build_separate_efo_workbook() -> openpyxl.Workbook:
 
 
 def test_parse_nics_combined_self_employed_line():
-    """Current EFO format: combined Class 2+4 line gets a single target with
-    custom_compute, alongside Class 1 employee/employer."""
+    """Current EFO format: combined Class 2+4 line gets a single direct
+    target alongside Class 1 employee/employer."""
     from policyengine_uk_data.targets.sources import obr as obr_module
 
     with patch.object(obr_module, "load_config", return_value=_FAKE_CONFIG):
@@ -106,11 +106,7 @@ def test_parse_nics_combined_self_employed_line():
     combined = next(t for t in targets if t.name == "obr/ni_self_employed")
     assert combined.variable == "ni_self_employed"
     assert combined.values[2024] == pytest.approx(4.8e9)
-    # The combined target is virtual — it must carry a custom_compute that
-    # sums the two underlying PE-UK variables. Without it the loss matrix
-    # falls through to the simple-GBP path and looks for a non-existent
-    # `ni_self_employed` PE-UK variable.
-    assert callable(combined.custom_compute)
+    assert combined.custom_compute is None
 
 
 def test_parse_nics_falls_back_to_separate_classes_for_old_efo():


### PR DESCRIPTION
## Summary

- Add an `obr/ni_self_employed` calibration target for the combined Class 2 + Class 4 line that recent OBR EFOs publish (e.g. March 2026), computed via a `custom_compute` that sums `ni_class_2 + ni_class_4` at the household level.
- Remove the `ni_class_3` entry from the OBR NIC parser. `ni_class_3` is an input variable in PolicyEngine UK with no formula and no dataset populates it — the matrix column would be a flat zero, so the target is inert and its calibration diagnostic is misleading.
- Add hermetic + signal regression tests covering both layouts (combined line, legacy separate Class 2 / Class 4 lines) and the Class 3 absence.

Closes #378. Partial close of #88 (Class 3 imputation remains a separate follow-up).

## Why

Two latent bugs surfaced during an audit of NI calibration:

1. **Self-employed NICs were silently uncalibrated against OBR.** The previous parser looked for `"Class 2 NICs"` and `"Class 4 NICs"` rows in EFO Table 3.4. The March 2026 EFO publishes a single combined line — `"Class 4 and Class 2 Self employed NICs"` — so neither legacy candidate matched and both targets dropped out of the registry. `Microsimulation.calculate("ni_class_2")` and `("ni_class_4")` *do* return signal in the dataset (~9.7k and ~7.6k non-zero people respectively, weighted totals ~£0.5bn and ~£3.5bn), so the optimiser had usable matrix columns — just nothing to aim them at.
2. **`ni_class_3` was registered but inert.** The OBR Class 3 row was emitted as a target, but `Microsimulation.calculate("ni_class_3")` returns a uniform zero (no formula, no dataset path). The calibrator saw a flat-zero matrix column and an OBR target it could never match. Reported as #378.

## What this PR does

### Combined self-employed target

The parser now lists `"Class 4 and Class 2 Self employed NICs"` and `"Class 2 and Class 4 Self employed NICs"` as the primary candidate labels for a new `obr/ni_self_employed` target. When the parser matches this line, it attaches a `custom_compute` callable that the loss-matrix builder uses instead of the simple-GBP fallback:

```python
def _compute_ni_self_employed_combined(ctx, target, year):
    class_2 = ctx.sim.calculate("ni_class_2")
    class_4 = ctx.sim.calculate("ni_class_4")
    return ctx.household_from_person(class_2 + class_4)
```

The legacy `"Class 2 NICs"` / `"Class 4 NICs"` candidate labels are retained so older or future EFOs that revert to separate rows continue to produce individual `obr/ni_class_2` / `obr/ni_class_4` targets.

### Smoke build on the live target matrix

Running `create_target_matrix` against `enhanced_frs_2023_24.h5` at `time_period=2025` now yields:

| Target | Non-zero households | OBR target |
|---|---:|---:|
| `obr/ni_employee` | 52,540 | £49.54bn |
| `obr/ni_employer` | 57,196 | £145.32bn |
| **`obr/ni_self_employed`** | **6,848** | **£2.90bn** |
| `obr/salary_sacrifice_employee_ni_relief` | 13,578 | £1.24bn |
| `obr/salary_sacrifice_employer_ni_relief` | 14,300 | £2.99bn |

`obr/ni_class_3` is absent from the matrix.

### Class 3 skip

`ni_class_3` is removed from the parser row-spec dict with a comment explaining (a) why it is currently inert, (b) why it is too small (~£50m vs ~£150bn total NICs) to justify a heuristic imputation, and (c) what would need to change to re-enable it. `obr.py` is the single place to revert if a Class 3 imputation lands in the future.

## Tests (28 added / changed, all passing locally)

`test_obr_nics.py` (parser, hermetic, no Microsimulation):

- `test_parse_nics_combined_self_employed_line` — current EFO layout: emits employee / employer / `ni_self_employed` (with `custom_compute`), and the combined target's value at 2024 is the £bn figure scaled to £.
- `test_parse_nics_falls_back_to_separate_classes_for_old_efo` — older EFO layout: emits the four individual classes (no combined).
- `test_parse_nics_intentionally_skips_class_3_in_combined_efo` — Class 3 is hidden in "Other NIC" in current EFOs and must not be emitted.
- `test_parse_nics_intentionally_skips_class_3_in_separate_efo` — even when an EFO publishes a Class 3 row, the parser drops it.
- `test_parse_nics_tolerates_alt_label_wording` — preserved: `Self-Employed` vs `self-employed` variants still match.

`test_obr_nic_signal.py` (signal, gated on the `enhanced_frs` fixture):

- `test_obr_nic_target_registry_includes_active_classes` — the three top-line NIC class targets are registered.
- `test_obr_ni_self_employed_target_uses_custom_compute` — the combined target carries a callable `custom_compute`; without it the loss matrix would look up a non-existent `ni_self_employed` PE-UK variable.
- `test_obr_ni_class_3_target_is_intentionally_absent` — neither the name nor the variable appear in the OBR target set.
- `test_active_nic_variable_has_nonzero_variation` (parametrised over `ni_employee`, `ni_employer`, `ni_class_2`, `ni_class_4`) — each PE-UK NIC variable produces non-zero variation across households.
- `test_self_employed_combined_compute_returns_nonzero` — the sum used by `custom_compute` produces a non-zero household-level vector.
- `test_ni_class_3_simulator_returns_uniform_zero` — direct evidence for why Class 3 is excluded; if PE-UK ever adds a formula or this repo adds an imputation, restore the parser row.

## Out of scope (follow-ups)

- **Class 3 imputation.** Voluntary contributions are paid by people topping up their state-pension record — a population that the FRS does not cleanly identify (lifetime work history isn't in the survey). At ~£50m / ~0.03% of total NICs the calibration benefit is small and the engineering risk (heuristic imputation distorting other targets) is non-trivial. Worth a focused follow-up issue if anyone needs Class 3 specifically.
- **Loss-matrix year resolver.** While verifying this PR I noticed `_resolve_value` won't fall back if the target's earliest year is in the future relative to the dataset (e.g. running on a 2023 dataset against a 2024+ EFO target gives `None`). Not introduced by this PR; flagging for a separate look.

## Sources

- [OBR EFO March 2026 — receipts detailed forecast tables](https://obr.uk/download/march-2026-economic-and-fiscal-outlook-detailed-forecast-tables-receipts/) (Sheet 3.4, the source of the combined Class 2+4 row).

## Related

- #88 — Add National Insurance targeting (this PR partially closes).
- #378 — Handle unpopulated `ni_class_3` target (this PR closes).
