### PR TITLE
Use SPI allowance deduction overrides

### DIFF
--- a/changelog.d/414.md
+++ b/changelog.d/414.md
@@ -1,0 +1,1 @@
+- Set SPI trading and property allowance overrides on the concrete deduction variables, matching the PE-UK removal of the pass-through allowance variables.

--- a/policyengine_uk_data/datasets/spi.py
+++ b/policyengine_uk_data/datasets/spi.py
@@ -1,4 +1,3 @@
-from policyengine_core.data import Dataset
 from policyengine_uk_data.storage import STORAGE_FOLDER
 import pandas as pd
 import numpy as np
@@ -128,10 +127,11 @@ def create_spi(
     person["private_pension_contributions"] = df.PSAV_XS
     person["pension_contributions_relief"] = df.PENSRLF
     person["self_employment_income"] = df.PROFITS
-    # HMRC seems to assume the trading and property allowance are already deducted
-    # (per record inspection of SREF 15494988 in 2020-21)
-    person["trading_allowance"] = np.zeros(len(df))
-    person["property_allowance"] = np.zeros(len(df))
+    # HMRC seems to assume the trading and property allowances are already
+    # deducted (per record inspection of SREF 15494988 in 2020-21), so SPI
+    # records override the actual deductions rather than the policy parameters.
+    person["trading_allowance_deduction"] = np.zeros(len(df))
+    person["property_allowance_deduction"] = np.zeros(len(df))
     person["savings_starter_rate_income"] = np.zeros(len(df))
     person["capital_allowances"] = df.CAPALL
     person["loss_relief"] = df.LOSSBF

--- a/policyengine_uk_data/tests/test_spi_allowance_deductions.py
+++ b/policyengine_uk_data/tests/test_spi_allowance_deductions.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+
+def test_spi_overrides_allowance_deductions_not_policy_parameters(tmp_path):
+    from policyengine_uk_data.datasets.spi import create_spi
+
+    row = {
+        "SREF": 1,
+        "FACT": 1,
+        "DIVIDENDS": 0,
+        "GIFTAID": 0,
+        "GORCODE": 7,
+        "INCBBS": 0,
+        "INCPROP": 1_000,
+        "PAY": 0,
+        "EPB": 0,
+        "EXPS": 0,
+        "PENSION": 0,
+        "PSAV_XS": 0,
+        "PENSRLF": 0,
+        "PROFITS": 1_000,
+        "CAPALL": 0,
+        "LOSSBF": 0,
+        "AGERANGE": 3,
+        "SRP": 0,
+        "TAX_CRED": 0,
+        "MOTHINC": 0,
+        "INCPBEN": 0,
+        "OSSBEN": 0,
+        "TAXTERM": 0,
+        "UBISJA": 0,
+        "OTHERINC": 0,
+        "GIFTINV": 0,
+        "OTHERINV": 0,
+        "COVNTS": 0,
+        "MOTHDED": 0,
+        "DEFICIEN": 0,
+        "MCAS": 0,
+        "BPADUE": 0,
+        "MAIND": 0,
+    }
+    spi_path = tmp_path / "spi.tab"
+    pd.DataFrame([row]).to_csv(spi_path, sep="\t", index=False)
+
+    dataset = create_spi(spi_path, fiscal_year=2020, output_file_path=None)
+
+    assert "trading_allowance" not in dataset.person
+    assert "property_allowance" not in dataset.person
+    assert dataset.person["trading_allowance_deduction"].iat[0] == 0
+    assert dataset.person["property_allowance_deduction"].iat[0] == 0


### PR DESCRIPTION
## Summary

- Move SPI trading/property allowance overrides from the removed pass-through allowance variables to the concrete deduction variables.
- Keep SPI's current treatment that HMRC income appears already net of trading/property allowances.
- Add a regression test that SPI emits `trading_allowance_deduction` and `property_allowance_deduction`, not the removed pass-through variable names.

Companion to PolicyEngine/policyengine-uk#1640.

## Tests

- `uv run pytest policyengine_uk_data/tests/test_spi_allowance_deductions.py -q`
- `uv run ruff check policyengine_uk_data/datasets/spi.py policyengine_uk_data/tests/test_spi_allowance_deductions.py`
