### PR TITLE
Harden UK data release manifest finalization

### DIFF
--- a/changelog.d/harden-manifest-finalization-contract.changed.md
+++ b/changelog.d/harden-manifest-finalization-contract.changed.md
@@ -1,0 +1,1 @@
+Treat UK data release manifests as the authoritative finalized bundle contract and make finalized upload retries idempotent.

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -18,6 +18,7 @@ from policyengine_uk_data.utils.hf_destinations import PRIVATE_REPO
 from policyengine_uk_data.utils.release_manifest import (
     RELEASE_MANIFEST_SCHEMA_VERSION,
     build_release_manifest,
+    validate_release_manifest,
 )
 
 # Synthetic fixture: this verifies manifest propagation, not the package dep range.
@@ -29,6 +30,12 @@ EXPECTED_CORE_PACKAGE = {
 EXPECTED_COMPATIBLE_CORE_PACKAGES = [
     {"name": "policyengine-core", "specifier": f"=={CORE_FIXTURE_VERSION}"}
 ]
+MODEL_BUILD_METADATA_FIXTURE = {
+    "version": "2.74.0",
+    "git_sha": "deadbeef",
+    "data_build_fingerprint": "sha256:fingerprint",
+    "core": EXPECTED_CORE_PACKAGE,
+}
 
 
 def _missing_revision_error() -> RevisionNotFoundError:
@@ -57,6 +64,40 @@ def _assert_single_uk_data_release_version(manifest: dict) -> None:
     for artifact in manifest["artifacts"].values():
         assert artifact["revision"] == release_version
         assert f"@{release_version}/" in artifact["uri"]
+
+
+def _uploaded_release_manifest(mock_api: MagicMock) -> dict:
+    operations = mock_api.create_commit.call_args.kwargs["operations"]
+    release_op = next(
+        operation
+        for operation in operations
+        if operation.path_in_repo == "releases/1.40.4/release_manifest.json"
+    )
+    return json.loads(release_op.path_or_fileobj.getvalue().decode("utf-8"))
+
+
+def _load_uploaded_manifest_after_commit(mock_api: MagicMock):
+    def fake_load_release_manifest(*args, **kwargs):
+        if kwargs.get("revision") == "1.40.4":
+            return _uploaded_release_manifest(mock_api)
+        return None
+
+    return fake_load_release_manifest
+
+
+def _valid_release_manifest(tmp_path: Path, content: bytes = b"enhanced-frs") -> dict:
+    dataset_path = _write_file(tmp_path / "enhanced_frs_2023_24.h5", content)
+    return build_release_manifest(
+        files_with_repo_paths=[(dataset_path, "enhanced_frs_2023_24.h5")],
+        version="1.40.4",
+        repo_id=PRIVATE_REPO,
+        model_package_version="2.74.0",
+        model_package_git_sha="deadbeef",
+        model_package_data_build_fingerprint="sha256:fingerprint",
+        core_package_metadata=EXPECTED_CORE_PACKAGE,
+        data_package_git_sha="cafebabe",
+        created_at="2026-04-10T12:00:00Z",
+    )
 
 
 def test_build_release_manifest_tracks_uk_release_artifacts(tmp_path):
@@ -163,6 +204,66 @@ def test_build_release_manifest_validates_against_bundle_contract(tmp_path):
     )
 
     policyengine_bundles.DataReleaseManifest.model_validate(manifest)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda manifest: manifest["artifacts"]["enhanced_frs_2023_24"].pop(
+                "sha256"
+            ),
+            "sha256",
+        ),
+        (
+            lambda manifest: manifest["artifacts"]["enhanced_frs_2023_24"].pop(
+                "size_bytes"
+            ),
+            "size_bytes",
+        ),
+        (
+            lambda manifest: manifest["artifacts"]["enhanced_frs_2023_24"].update(
+                {"revision": "stale-version"}
+            ),
+            "revision",
+        ),
+        (
+            lambda manifest: manifest["build"].pop("built_with_core_package"),
+            "built_with_core_package",
+        ),
+        (
+            lambda manifest: manifest["build"]["built_with_model_package"].pop(
+                "data_build_fingerprint"
+            ),
+            "data_build_fingerprint",
+        ),
+        (
+            lambda manifest: manifest.update({"compatible_core_packages": []}),
+            "compatible_core_packages",
+        ),
+        (
+            lambda manifest: manifest["default_datasets"].update(
+                {"national": "missing_artifact"}
+            ),
+            "default_datasets",
+        ),
+    ],
+)
+def test_validate_release_manifest_rejects_incomplete_bundle_contract(
+    tmp_path,
+    mutate,
+    match,
+):
+    manifest = _valid_release_manifest(tmp_path)
+    mutate(manifest)
+
+    with pytest.raises(ValueError, match=match):
+        validate_release_manifest(
+            manifest,
+            version="1.40.4",
+            repo_id=PRIVATE_REPO,
+            repo_type="model",
+        )
 
 
 def test_build_release_manifest_rejects_unknown_hf_repo(tmp_path):
@@ -307,6 +408,25 @@ def test_load_release_manifest_from_hf_uses_explicit_revision_when_requested(tmp
     assert mock_download.call_args.kwargs["revision"] == "1.40.4"
 
 
+def test_load_release_manifest_from_hf_can_require_versioned_path():
+    with patch(
+        "policyengine_uk_data.utils.data_upload.hf_hub_download",
+        side_effect=EntryNotFoundError("missing"),
+    ) as mock_download:
+        manifest = load_release_manifest_from_hf(
+            version="1.40.4",
+            revision="1.40.4",
+            include_current_manifest=False,
+        )
+
+    assert manifest is None
+    mock_download.assert_called_once()
+    assert (
+        mock_download.call_args.kwargs["filename"]
+        == "releases/1.40.4/release_manifest.json"
+    )
+
+
 def test_load_release_manifest_from_hf_returns_none_when_revision_is_missing():
     with patch(
         "policyengine_uk_data.utils.data_upload.hf_hub_download",
@@ -357,16 +477,11 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
         patch("policyengine_uk_data.utils.data_upload.HfApi", return_value=mock_api),
         patch(
             "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
-            return_value=None,
+            side_effect=_load_uploaded_manifest_after_commit(mock_api),
         ),
         patch(
             "policyengine_uk_data.utils.data_upload._get_model_package_build_metadata",
-            return_value={
-                "version": "2.74.0",
-                "git_sha": "deadbeef",
-                "data_build_fingerprint": "sha256:fingerprint",
-                "core": EXPECTED_CORE_PACKAGE,
-            },
+            return_value=MODEL_BUILD_METADATA_FIXTURE,
         ),
         patch(
             "policyengine_uk_data.utils.data_upload._get_data_package_git_sha",
@@ -444,17 +559,15 @@ def test_upload_files_to_hf_refreshes_same_version_unfinalized_manifest(tmp_path
         patch(
             "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
             side_effect=lambda *args, **kwargs: (
-                None if kwargs.get("revision") == "1.40.4" else existing_manifest
+                _uploaded_release_manifest(mock_api)
+                if kwargs.get("revision") == "1.40.4"
+                and mock_api.create_commit.call_args is not None
+                else existing_manifest
             ),
         ),
         patch(
             "policyengine_uk_data.utils.data_upload._get_model_package_build_metadata",
-            return_value={
-                "version": "2.74.0",
-                "git_sha": "deadbeef",
-                "data_build_fingerprint": "sha256:fingerprint",
-                "core": EXPECTED_CORE_PACKAGE,
-            },
+            return_value=MODEL_BUILD_METADATA_FIXTURE,
         ),
         patch(
             "policyengine_uk_data.utils.data_upload._get_data_package_git_sha",
@@ -489,34 +602,17 @@ def test_upload_files_to_hf_refreshes_same_version_unfinalized_manifest(tmp_path
     )
 
 
-def test_upload_files_to_hf_rejects_finalized_release(tmp_path):
+def test_upload_files_to_hf_noops_when_finalized_manifest_matches(tmp_path):
     dataset_path = _write_file(
         tmp_path / "enhanced_frs_2023_24.h5",
         b"enhanced-frs",
     )
-    finalized_manifest = {
-        "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
-        "data_package": {
-            "name": "policyengine-uk-data",
-            "version": "1.40.4",
-        },
-        "compatible_model_packages": [
-            {"name": "policyengine-uk", "specifier": "==2.74.0"}
-        ],
-        "default_datasets": {"national": "enhanced_frs_2023_24"},
-        "artifacts": {
-            "enhanced_frs_2023_24": {
-                "kind": "microdata",
-                "path": "enhanced_frs_2023_24.h5",
-                "repo_id": PRIVATE_REPO,
-                "revision": "1.40.4",
-                "sha256": _sha256(b"enhanced-frs"),
-                "size_bytes": len(b"enhanced-frs"),
-            }
-        },
-    }
+    finalized_manifest = _valid_release_manifest(
+        tmp_path / "finalized",
+        b"enhanced-frs",
+    )
     mock_api = MagicMock()
-    mock_api.repo_info.side_effect = _missing_revision_error()
+    mock_api.repo_info.return_value = MagicMock(sha="finalized-sha")
 
     with (
         patch("policyengine_uk_data.utils.data_upload.HfApi", return_value=mock_api),
@@ -526,17 +622,64 @@ def test_upload_files_to_hf_rejects_finalized_release(tmp_path):
                 finalized_manifest if kwargs.get("revision") == "1.40.4" else None
             ),
         ),
+        patch(
+            "policyengine_uk_data.utils.data_upload._get_model_package_build_metadata",
+            return_value=MODEL_BUILD_METADATA_FIXTURE,
+        ),
+        patch(
+            "policyengine_uk_data.utils.data_upload._get_data_package_git_sha",
+            return_value="cafebabe",
+        ),
     ):
-        with pytest.raises(RuntimeError, match="already finalized"):
+        upload_files_to_hf(
+            files=[dataset_path],
+            version="1.40.4",
+        )
+
+    mock_api.create_commit.assert_not_called()
+    mock_api.create_tag.assert_not_called()
+
+
+def test_upload_files_to_hf_rejects_finalized_manifest_mismatch(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_frs_2023_24.h5",
+        b"enhanced-frs-v2",
+    )
+    finalized_manifest = _valid_release_manifest(
+        tmp_path / "finalized",
+        b"enhanced-frs",
+    )
+    mock_api = MagicMock()
+    mock_api.repo_info.return_value = MagicMock(sha="finalized-sha")
+
+    with (
+        patch("policyengine_uk_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
+            side_effect=lambda *args, **kwargs: (
+                finalized_manifest if kwargs.get("revision") == "1.40.4" else None
+            ),
+        ),
+        patch(
+            "policyengine_uk_data.utils.data_upload._get_model_package_build_metadata",
+            return_value=MODEL_BUILD_METADATA_FIXTURE,
+        ),
+        patch(
+            "policyengine_uk_data.utils.data_upload._get_data_package_git_sha",
+            return_value="cafebabe",
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="different release manifest"):
             upload_files_to_hf(
                 files=[dataset_path],
                 version="1.40.4",
             )
 
     mock_api.create_commit.assert_not_called()
+    mock_api.create_tag.assert_not_called()
 
 
-def test_upload_files_to_hf_rejects_existing_tag_before_commit(tmp_path):
+def test_upload_files_to_hf_rejects_existing_tag_without_manifest(tmp_path):
     dataset_path = _write_file(
         tmp_path / "enhanced_frs_2023_24.h5",
         b"enhanced-frs",
@@ -551,12 +694,15 @@ def test_upload_files_to_hf_rejects_existing_tag_before_commit(tmp_path):
             return_value=None,
         ) as mock_load_release_manifest,
     ):
-        with pytest.raises(RuntimeError, match="already finalized"):
+        with pytest.raises(RuntimeError, match="no versioned release_manifest.json"):
             upload_files_to_hf(
                 files=[dataset_path],
                 version="1.40.4",
             )
 
-    mock_load_release_manifest.assert_not_called()
+    mock_load_release_manifest.assert_called_once()
+    assert (
+        mock_load_release_manifest.call_args.kwargs["include_current_manifest"] is False
+    )
     mock_api.create_commit.assert_not_called()
     mock_api.create_tag.assert_not_called()

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -11,6 +11,7 @@ from huggingface_hub.errors import EntryNotFoundError, RevisionNotFoundError
 
 from policyengine_uk_data.utils.data_upload import (
     _get_model_package_version,
+    get_finalized_release_manifest,
     load_release_manifest_from_hf,
     upload_files_to_hf,
 )
@@ -238,6 +239,18 @@ def test_build_release_manifest_validates_against_bundle_contract(tmp_path):
             "built_with_core_package",
         ),
         (
+            lambda manifest: manifest["build"]["built_with_model_package"].update(
+                {"name": "policyengine-uk-copy"}
+            ),
+            "built_with_model_package.name",
+        ),
+        (
+            lambda manifest: manifest["build"]["built_with_core_package"].update(
+                {"name": "policyengine-core-copy"}
+            ),
+            "built_with_core_package.name",
+        ),
+        (
             lambda manifest: manifest["build"]["built_with_model_package"].pop(
                 "data_build_fingerprint"
             ),
@@ -414,6 +427,23 @@ def test_load_release_manifest_from_hf_uses_explicit_revision_when_requested(tmp
     assert mock_download.call_args.kwargs["revision"] == "1.40.4"
 
 
+def test_load_release_manifest_from_hf_uses_explicit_token(tmp_path):
+    manifest_path = tmp_path / "release_manifest.json"
+    manifest_path.write_text('{"data_package": {"version": "1.40.4"}}')
+
+    with patch(
+        "policyengine_uk_data.utils.data_upload.hf_hub_download",
+        return_value=str(manifest_path),
+    ) as mock_download:
+        manifest = load_release_manifest_from_hf(
+            version="1.40.4",
+            token="explicit-token",
+        )
+
+    assert manifest["data_package"]["version"] == "1.40.4"
+    assert mock_download.call_args.kwargs["token"] == "explicit-token"
+
+
 def test_load_release_manifest_from_hf_can_require_versioned_path():
     with patch(
         "policyengine_uk_data.utils.data_upload.hf_hub_download",
@@ -445,6 +475,32 @@ def test_load_release_manifest_from_hf_returns_none_when_revision_is_missing():
             )
             is None
         )
+
+
+def test_get_finalized_release_manifest_forwards_explicit_token(tmp_path):
+    finalized_manifest = _valid_release_manifest(tmp_path)
+    mock_api = MagicMock()
+    mock_api.repo_info.return_value = MagicMock(sha="finalized-sha")
+
+    with patch(
+        "policyengine_uk_data.utils.data_upload.load_release_manifest_from_hf",
+        return_value=finalized_manifest,
+    ) as mock_load_release_manifest:
+        manifest = get_finalized_release_manifest(
+            version="1.40.4",
+            hf_repo_name=PRIVATE_REPO,
+            hf_repo_type="model",
+            token="explicit-token",
+            api=mock_api,
+        )
+
+    assert manifest == finalized_manifest
+    assert mock_api.repo_info.call_args.kwargs["token"] == "explicit-token"
+    assert mock_load_release_manifest.call_args.kwargs["token"] == "explicit-token"
+    assert (
+        mock_load_release_manifest.call_args.kwargs["include_top_level_manifest"]
+        is False
+    )
 
 
 def test_get_model_package_version_prefers_imported_checkout(tmp_path):
@@ -532,6 +588,7 @@ def test_upload_files_to_hf_adds_uk_release_manifest_operations(tmp_path):
     assert (
         manifest["build"]["built_with_model_package"]["core"] == EXPECTED_CORE_PACKAGE
     )
+    assert mock_api.create_commit.call_args.kwargs["token"] == "token"
 
 
 def test_upload_files_to_hf_refreshes_same_version_unfinalized_manifest(tmp_path):

--- a/policyengine_uk_data/tests/test_release_manifest.py
+++ b/policyengine_uk_data/tests/test_release_manifest.py
@@ -228,6 +228,12 @@ def test_build_release_manifest_validates_against_bundle_contract(tmp_path):
             "revision",
         ),
         (
+            lambda manifest: manifest["artifacts"]["enhanced_frs_2023_24"].update(
+                {"uri": "hf://model/policyengine/wrong@1.40.4/enhanced_frs_2023_24.h5"}
+            ),
+            "uri",
+        ),
+        (
             lambda manifest: manifest["build"].pop("built_with_core_package"),
             "built_with_core_package",
         ),
@@ -416,7 +422,7 @@ def test_load_release_manifest_from_hf_can_require_versioned_path():
         manifest = load_release_manifest_from_hf(
             version="1.40.4",
             revision="1.40.4",
-            include_current_manifest=False,
+            include_top_level_manifest=False,
         )
 
     assert manifest is None
@@ -702,7 +708,8 @@ def test_upload_files_to_hf_rejects_existing_tag_without_manifest(tmp_path):
 
     mock_load_release_manifest.assert_called_once()
     assert (
-        mock_load_release_manifest.call_args.kwargs["include_current_manifest"] is False
+        mock_load_release_manifest.call_args.kwargs["include_top_level_manifest"]
+        is False
     )
     mock_api.create_commit.assert_not_called()
     mock_api.create_tag.assert_not_called()

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -16,6 +16,7 @@ import tomllib
 from policyengine_uk_data.utils.release_manifest import (
     build_release_manifest,
     serialize_release_manifest,
+    validate_release_manifest,
 )
 from policyengine_uk_data.utils.hf_destinations import PRIVATE_REPO, PUBLIC_REPO
 
@@ -140,12 +141,12 @@ def load_release_manifest_from_hf(
     hf_repo_name: str = PRIVATE_REPO,
     hf_repo_type: str = "model",
     revision: Optional[str] = None,
+    include_current_manifest: bool = True,
 ) -> Optional[Dict]:
     token = os.environ.get("HUGGING_FACE_TOKEN")
-    candidate_paths = [
-        f"releases/{version}/{RELEASE_MANIFEST_PATH}",
-        RELEASE_MANIFEST_PATH,
-    ]
+    candidate_paths = [f"releases/{version}/{RELEASE_MANIFEST_PATH}"]
+    if include_current_manifest:
+        candidate_paths.append(RELEASE_MANIFEST_PATH)
 
     for path_in_repo in candidate_paths:
         try:
@@ -194,13 +195,13 @@ def _get_release_tag_revision(
         return None
 
 
-def assert_release_not_finalized(
+def get_finalized_release_manifest(
     version: str,
     hf_repo_name: str = PRIVATE_REPO,
     hf_repo_type: str = "model",
     token: Optional[str] = None,
     api: Optional[HfApi] = None,
-) -> None:
+) -> Optional[Dict]:
     tagged_revision = _get_release_tag_revision(
         version=version,
         hf_repo_name=hf_repo_name,
@@ -208,24 +209,28 @@ def assert_release_not_finalized(
         token=token,
         api=api,
     )
-    if tagged_revision is not None:
-        raise RuntimeError(
-            f"Release {version} is already finalized on {hf_repo_name} at "
-            f"{tagged_revision}. Refusing to mutate release manifest state "
-            "after the tag exists."
-        )
+    if tagged_revision is None:
+        return None
 
     finalized_manifest = load_release_manifest_from_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
         revision=version,
+        include_current_manifest=False,
     )
-    if finalized_manifest is not None:
+    if finalized_manifest is None:
         raise RuntimeError(
-            f"Release {version} is already finalized on {hf_repo_name}. "
-            "Refusing to mutate release manifest state after the tag exists."
+            f"Release {version} is tagged on {hf_repo_name} at {tagged_revision}, "
+            f"but no versioned {RELEASE_MANIFEST_PATH} is available at that tag."
         )
+    validate_release_manifest(
+        finalized_manifest,
+        version=version,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+    )
+    return finalized_manifest
 
 
 def create_release_tag(
@@ -303,6 +308,12 @@ def create_release_manifest_commit_operations(
         data_package_git_sha=data_package_git_sha,
         existing_manifest=existing_manifest,
     )
+    validate_release_manifest(
+        manifest,
+        version=version,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+    )
     manifest_payload = serialize_release_manifest(manifest)
     operations = [
         CommitOperationAdd(
@@ -354,13 +365,6 @@ def upload_files_to_hf(
     token = os.environ.get(
         "HUGGING_FACE_TOKEN",
     )
-    assert_release_not_finalized(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-        token=token,
-        api=api,
-    )
     hf_operations = []
     files_with_repo_paths = []
 
@@ -377,7 +381,14 @@ def upload_files_to_hf(
             )
         )
 
-    existing_manifest = load_release_manifest_from_hf(
+    finalized_manifest = get_finalized_release_manifest(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+        token=token,
+        api=api,
+    )
+    existing_manifest = finalized_manifest or load_release_manifest_from_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
@@ -386,7 +397,7 @@ def upload_files_to_hf(
     core_package_metadata = (
         model_build_metadata.get("core") or _get_core_package_runtime_metadata()
     )
-    _, manifest_operations = create_release_manifest_commit_operations(
+    candidate_manifest, manifest_operations = create_release_manifest_commit_operations(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
         hf_repo_name=hf_repo_name,
@@ -400,6 +411,18 @@ def upload_files_to_hf(
         data_package_git_sha=_get_data_package_git_sha(),
         existing_manifest=existing_manifest,
     )
+    if finalized_manifest is not None:
+        if candidate_manifest == finalized_manifest:
+            logging.info(
+                "Release %s is already finalized on %s with the same release manifest.",
+                version,
+                hf_repo_name,
+            )
+            return
+        raise RuntimeError(
+            f"Release {version} is already finalized on {hf_repo_name} with a "
+            "different release manifest. Refusing to mutate release state."
+        )
     hf_operations.extend(manifest_operations)
 
     commit_info = api.create_commit(
@@ -419,6 +442,30 @@ def upload_files_to_hf(
         token=token,
         api=api,
     )
+
+    tagged_manifest = load_release_manifest_from_hf(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+        revision=version,
+        include_current_manifest=False,
+    )
+    if tagged_manifest is None:
+        raise RuntimeError(
+            f"Release {version} was tagged on {hf_repo_name}, but no versioned "
+            f"{RELEASE_MANIFEST_PATH} is available at that tag."
+        )
+    validate_release_manifest(
+        tagged_manifest,
+        version=version,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+    )
+    if tagged_manifest != candidate_manifest:
+        raise RuntimeError(
+            f"Release {version} was tagged on {hf_repo_name}, but the versioned "
+            "release manifest differs from the uploaded manifest."
+        )
 
 
 def upload_files_to_gcs(

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -142,8 +142,9 @@ def load_release_manifest_from_hf(
     hf_repo_type: str = "model",
     revision: Optional[str] = None,
     include_top_level_manifest: bool = True,
+    token: Optional[str] = None,
 ) -> Optional[Dict]:
-    token = os.environ.get("HUGGING_FACE_TOKEN")
+    token = token or os.environ.get("HUGGING_FACE_TOKEN")
     candidate_paths = [f"releases/{version}/{RELEASE_MANIFEST_PATH}"]
     if include_top_level_manifest:
         candidate_paths.append(RELEASE_MANIFEST_PATH)
@@ -218,6 +219,7 @@ def get_finalized_release_manifest(
         hf_repo_type=hf_repo_type,
         revision=version,
         include_top_level_manifest=False,
+        token=token,
     )
     if finalized_manifest is None:
         raise RuntimeError(
@@ -313,6 +315,7 @@ def create_release_manifest_commit_operations(
         version=version,
         repo_id=hf_repo_name,
         repo_type=hf_repo_type,
+        model_package_name=model_package_name,
     )
     manifest_payload = serialize_release_manifest(manifest)
     operations = [
@@ -392,6 +395,7 @@ def upload_files_to_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
+        token=token,
     )
     model_build_metadata = _get_model_package_build_metadata()
     core_package_metadata = (
@@ -449,6 +453,7 @@ def upload_files_to_hf(
         hf_repo_type=hf_repo_type,
         revision=version,
         include_top_level_manifest=False,
+        token=token,
     )
     if tagged_manifest is None:
         raise RuntimeError(

--- a/policyengine_uk_data/utils/data_upload.py
+++ b/policyengine_uk_data/utils/data_upload.py
@@ -141,11 +141,11 @@ def load_release_manifest_from_hf(
     hf_repo_name: str = PRIVATE_REPO,
     hf_repo_type: str = "model",
     revision: Optional[str] = None,
-    include_current_manifest: bool = True,
+    include_top_level_manifest: bool = True,
 ) -> Optional[Dict]:
     token = os.environ.get("HUGGING_FACE_TOKEN")
     candidate_paths = [f"releases/{version}/{RELEASE_MANIFEST_PATH}"]
-    if include_current_manifest:
+    if include_top_level_manifest:
         candidate_paths.append(RELEASE_MANIFEST_PATH)
 
     for path_in_repo in candidate_paths:
@@ -217,7 +217,7 @@ def get_finalized_release_manifest(
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
         revision=version,
-        include_current_manifest=False,
+        include_top_level_manifest=False,
     )
     if finalized_manifest is None:
         raise RuntimeError(
@@ -448,7 +448,7 @@ def upload_files_to_hf(
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
         revision=version,
-        include_current_manifest=False,
+        include_top_level_manifest=False,
     )
     if tagged_manifest is None:
         raise RuntimeError(

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -188,21 +188,12 @@ def _require_exact_compatibility(
         )
 
 
-def validate_release_manifest(
+def _validate_manifest_identity(
     manifest: Mapping[str, Any],
     *,
     version: str,
-    repo_id: str | None = None,
-    repo_type: str | None = None,
     data_package_name: str = "policyengine-uk-data",
 ) -> None:
-    """Validate the bundle-facing UK data release contract.
-
-    ``release_manifest.json`` is the authoritative signal that a release can be
-    consumed by bundles. This validation is intentionally stricter than the
-    general schema: a finalized release must include concrete artifact hashes,
-    sizes, runtime package metadata, and exact compatibility specifiers.
-    """
     if manifest.get("schema_version") != RELEASE_MANIFEST_SCHEMA_VERSION:
         raise ValueError(
             "release_manifest.schema_version must equal "
@@ -217,6 +208,14 @@ def validate_release_manifest(
     if data_package.get("version") != version:
         raise ValueError(f"release_manifest.data_package.version must equal {version}.")
 
+
+def _validate_artifact_release_metadata(
+    manifest: Mapping[str, Any],
+    *,
+    version: str,
+    repo_id: str | None,
+    repo_type: str | None,
+) -> None:
     metadata = _require_mapping(manifest.get("metadata"), "metadata")
     artifact_release = _require_mapping(
         metadata.get("artifact_release"),
@@ -242,6 +241,8 @@ def validate_release_manifest(
                 f"{expected_visibility}."
             )
 
+
+def _validate_build_and_compatibility(manifest: Mapping[str, Any]) -> None:
     build = _require_mapping(manifest.get("build"), "build")
     build_metadata = _require_mapping(build.get("metadata"), "build.metadata")
     _require_string(
@@ -292,14 +293,22 @@ def validate_release_manifest(
         field="compatible_core_packages",
     )
 
+
+def _validate_artifacts(
+    manifest: Mapping[str, Any],
+    *,
+    version: str,
+    repo_id: str | None,
+    repo_type: str | None,
+) -> Mapping[str, Any]:
     artifacts = _require_mapping(manifest.get("artifacts"), "artifacts")
     if not artifacts:
         raise ValueError("release_manifest.artifacts must not be empty.")
     for artifact_key, artifact in artifacts.items():
         field_prefix = f"artifacts.{artifact_key}"
         artifact = _require_mapping(artifact, field_prefix)
-        _require_string(artifact.get("uri"), f"{field_prefix}.uri")
-        _require_string(artifact.get("path"), f"{field_prefix}.path")
+        artifact_uri = _require_string(artifact.get("uri"), f"{field_prefix}.uri")
+        artifact_path = _require_string(artifact.get("path"), f"{field_prefix}.path")
         artifact_repo_id = _require_string(
             artifact.get("repo_id"), f"{field_prefix}.repo_id"
         )
@@ -307,10 +316,22 @@ def validate_release_manifest(
             raise ValueError(
                 f"release_manifest.{field_prefix}.repo_id must equal {repo_id}."
             )
+        expected_repo_id = repo_id or artifact_repo_id
         if artifact.get("revision") != version:
             raise ValueError(
                 f"release_manifest.{field_prefix}.revision must equal {version}."
             )
+        if repo_type is not None:
+            expected_uri = _artifact_uri(
+                repo_id=expected_repo_id,
+                repo_type=repo_type,
+                revision=version,
+                path_in_repo=artifact_path,
+            )
+            if artifact_uri != expected_uri:
+                raise ValueError(
+                    f"release_manifest.{field_prefix}.uri must equal {expected_uri}."
+                )
         _require_string(artifact.get("sha256"), f"{field_prefix}.sha256")
         _require_positive_int(artifact.get("size_bytes"), f"{field_prefix}.size_bytes")
         artifact_metadata = _require_mapping(
@@ -329,6 +350,13 @@ def validate_release_manifest(
                     f"{expected_visibility}."
                 )
 
+    return artifacts
+
+
+def _validate_default_datasets(
+    manifest: Mapping[str, Any],
+    artifacts: Mapping[str, Any],
+) -> None:
     default_datasets = _require_mapping(
         manifest.get("default_datasets"),
         "default_datasets",
@@ -341,6 +369,42 @@ def validate_release_manifest(
                 "release_manifest.default_datasets "
                 f"{default_key!r} points to missing artifact {artifact_key!r}."
             )
+
+
+def validate_release_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    version: str,
+    repo_id: str | None = None,
+    repo_type: str | None = None,
+    data_package_name: str = "policyengine-uk-data",
+) -> None:
+    """Validate the bundle-facing UK data release contract.
+
+    ``release_manifest.json`` is the authoritative signal that a release can be
+    consumed by bundles. This validation is intentionally stricter than the
+    general schema: a finalized release must include concrete artifact hashes,
+    sizes, runtime package metadata, and exact compatibility specifiers.
+    """
+    _validate_manifest_identity(
+        manifest,
+        version=version,
+        data_package_name=data_package_name,
+    )
+    _validate_artifact_release_metadata(
+        manifest,
+        version=version,
+        repo_id=repo_id,
+        repo_type=repo_type,
+    )
+    _validate_build_and_compatibility(manifest)
+    artifacts = _validate_artifacts(
+        manifest,
+        version=version,
+        repo_id=repo_id,
+        repo_type=repo_type,
+    )
+    _validate_default_datasets(manifest, artifacts)
 
 
 def _new_release_manifest(

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -242,7 +242,12 @@ def _validate_artifact_release_metadata(
             )
 
 
-def _validate_build_and_compatibility(manifest: Mapping[str, Any]) -> None:
+def _validate_build_and_compatibility(
+    manifest: Mapping[str, Any],
+    *,
+    model_package_name: str,
+    core_package_name: str,
+) -> None:
     build = _require_mapping(manifest.get("build"), "build")
     build_metadata = _require_mapping(build.get("metadata"), "build.metadata")
     _require_string(
@@ -258,6 +263,11 @@ def _validate_build_and_compatibility(manifest: Mapping[str, Any]) -> None:
         model_package.get("name"),
         "build.built_with_model_package.name",
     )
+    if model_name != model_package_name:
+        raise ValueError(
+            "release_manifest.build.built_with_model_package.name must equal "
+            f"{model_package_name}."
+        )
     model_version = _require_string(
         model_package.get("version"),
         "build.built_with_model_package.version",
@@ -275,6 +285,11 @@ def _validate_build_and_compatibility(manifest: Mapping[str, Any]) -> None:
         core_package.get("name"),
         "build.built_with_core_package.name",
     )
+    if core_name != core_package_name:
+        raise ValueError(
+            "release_manifest.build.built_with_core_package.name must equal "
+            f"{core_package_name}."
+        )
     core_version = _require_string(
         core_package.get("version"),
         "build.built_with_core_package.version",
@@ -378,6 +393,8 @@ def validate_release_manifest(
     repo_id: str | None = None,
     repo_type: str | None = None,
     data_package_name: str = "policyengine-uk-data",
+    model_package_name: str = "policyengine-uk",
+    core_package_name: str = "policyengine-core",
 ) -> None:
     """Validate the bundle-facing UK data release contract.
 
@@ -397,7 +414,11 @@ def validate_release_manifest(
         repo_id=repo_id,
         repo_type=repo_type,
     )
-    _validate_build_and_compatibility(manifest)
+    _validate_build_and_compatibility(
+        manifest,
+        model_package_name=model_package_name,
+        core_package_name=core_package_name,
+    )
     artifacts = _validate_artifacts(
         manifest,
         version=version,

--- a/policyengine_uk_data/utils/release_manifest.py
+++ b/policyengine_uk_data/utils/release_manifest.py
@@ -153,6 +153,196 @@ def _core_package_compatibility(
     ]
 
 
+def _require_mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"release_manifest.{field} must be an object.")
+    return value
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"release_manifest.{field} must be a non-empty string.")
+    return value
+
+
+def _require_positive_int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or value <= 0:
+        raise ValueError(f"release_manifest.{field} must be a positive integer.")
+    return value
+
+
+def _require_exact_compatibility(
+    entries: Any,
+    *,
+    package_name: str,
+    package_version: str,
+    field: str,
+) -> None:
+    if not isinstance(entries, list):
+        raise ValueError(f"release_manifest.{field} must be a list.")
+    expected = {"name": package_name, "specifier": f"=={package_version}"}
+    if expected not in entries:
+        raise ValueError(
+            f"release_manifest.{field} must include exact specifier "
+            f"{package_name}=={package_version}."
+        )
+
+
+def validate_release_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    version: str,
+    repo_id: str | None = None,
+    repo_type: str | None = None,
+    data_package_name: str = "policyengine-uk-data",
+) -> None:
+    """Validate the bundle-facing UK data release contract.
+
+    ``release_manifest.json`` is the authoritative signal that a release can be
+    consumed by bundles. This validation is intentionally stricter than the
+    general schema: a finalized release must include concrete artifact hashes,
+    sizes, runtime package metadata, and exact compatibility specifiers.
+    """
+    if manifest.get("schema_version") != RELEASE_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            "release_manifest.schema_version must equal "
+            f"{RELEASE_MANIFEST_SCHEMA_VERSION}."
+        )
+
+    data_package = _require_mapping(manifest.get("data_package"), "data_package")
+    if data_package.get("name") != data_package_name:
+        raise ValueError(
+            f"release_manifest.data_package.name must equal {data_package_name}."
+        )
+    if data_package.get("version") != version:
+        raise ValueError(f"release_manifest.data_package.version must equal {version}.")
+
+    metadata = _require_mapping(manifest.get("metadata"), "metadata")
+    artifact_release = _require_mapping(
+        metadata.get("artifact_release"),
+        "metadata.artifact_release",
+    )
+    if repo_id is not None and artifact_release.get("repo_id") != repo_id:
+        raise ValueError(
+            f"release_manifest.metadata.artifact_release.repo_id must equal {repo_id}."
+        )
+    if repo_type is not None and artifact_release.get("repo_type") != repo_type:
+        raise ValueError(
+            f"release_manifest.metadata.artifact_release.repo_type must equal {repo_type}."
+        )
+    if artifact_release.get("version") != version:
+        raise ValueError(
+            f"release_manifest.metadata.artifact_release.version must equal {version}."
+        )
+    if repo_id is not None:
+        expected_visibility = _artifact_visibility(repo_id)
+        if artifact_release.get("visibility") != expected_visibility:
+            raise ValueError(
+                "release_manifest.metadata.artifact_release.visibility must equal "
+                f"{expected_visibility}."
+            )
+
+    build = _require_mapping(manifest.get("build"), "build")
+    build_metadata = _require_mapping(build.get("metadata"), "build.metadata")
+    _require_string(
+        build_metadata.get("data_package_git_sha"),
+        "build.metadata.data_package_git_sha",
+    )
+
+    model_package = _require_mapping(
+        build.get("built_with_model_package"),
+        "build.built_with_model_package",
+    )
+    model_name = _require_string(
+        model_package.get("name"),
+        "build.built_with_model_package.name",
+    )
+    model_version = _require_string(
+        model_package.get("version"),
+        "build.built_with_model_package.version",
+    )
+    _require_string(
+        model_package.get("data_build_fingerprint"),
+        "build.built_with_model_package.data_build_fingerprint",
+    )
+
+    core_package = _require_mapping(
+        build.get("built_with_core_package"),
+        "build.built_with_core_package",
+    )
+    core_name = _require_string(
+        core_package.get("name"),
+        "build.built_with_core_package.name",
+    )
+    core_version = _require_string(
+        core_package.get("version"),
+        "build.built_with_core_package.version",
+    )
+
+    _require_exact_compatibility(
+        manifest.get("compatible_model_packages"),
+        package_name=model_name,
+        package_version=model_version,
+        field="compatible_model_packages",
+    )
+    _require_exact_compatibility(
+        manifest.get("compatible_core_packages"),
+        package_name=core_name,
+        package_version=core_version,
+        field="compatible_core_packages",
+    )
+
+    artifacts = _require_mapping(manifest.get("artifacts"), "artifacts")
+    if not artifacts:
+        raise ValueError("release_manifest.artifacts must not be empty.")
+    for artifact_key, artifact in artifacts.items():
+        field_prefix = f"artifacts.{artifact_key}"
+        artifact = _require_mapping(artifact, field_prefix)
+        _require_string(artifact.get("uri"), f"{field_prefix}.uri")
+        _require_string(artifact.get("path"), f"{field_prefix}.path")
+        artifact_repo_id = _require_string(
+            artifact.get("repo_id"), f"{field_prefix}.repo_id"
+        )
+        if repo_id is not None and artifact_repo_id != repo_id:
+            raise ValueError(
+                f"release_manifest.{field_prefix}.repo_id must equal {repo_id}."
+            )
+        if artifact.get("revision") != version:
+            raise ValueError(
+                f"release_manifest.{field_prefix}.revision must equal {version}."
+            )
+        _require_string(artifact.get("sha256"), f"{field_prefix}.sha256")
+        _require_positive_int(artifact.get("size_bytes"), f"{field_prefix}.size_bytes")
+        artifact_metadata = _require_mapping(
+            artifact.get("metadata"),
+            f"{field_prefix}.metadata",
+        )
+        if repo_type is not None and artifact_metadata.get("repo_type") != repo_type:
+            raise ValueError(
+                f"release_manifest.{field_prefix}.metadata.repo_type must equal {repo_type}."
+            )
+        if repo_id is not None:
+            expected_visibility = _artifact_visibility(repo_id)
+            if artifact_metadata.get("visibility") != expected_visibility:
+                raise ValueError(
+                    f"release_manifest.{field_prefix}.metadata.visibility must equal "
+                    f"{expected_visibility}."
+                )
+
+    default_datasets = _require_mapping(
+        manifest.get("default_datasets"),
+        "default_datasets",
+    )
+    if not default_datasets:
+        raise ValueError("release_manifest.default_datasets must not be empty.")
+    for default_key, artifact_key in default_datasets.items():
+        if artifact_key not in artifacts:
+            raise ValueError(
+                "release_manifest.default_datasets "
+                f"{default_key!r} points to missing artifact {artifact_key!r}."
+            )
+
+
 def _new_release_manifest(
     *,
     version: str,


### PR DESCRIPTION
Fixes #396

## Summary

- Treat the versioned `releases/<version>/release_manifest.json` at the HF tag as the authoritative finalized bundle contract.
- Add strict release manifest validation for artifact hashes, sizes, defaults, build metadata, exact UK package compatibility, and exact core compatibility.
- Make finalized upload retries idempotent only when the rebuilt candidate manifest exactly matches the finalized manifest.
- Hard-fail existing tags that lack a versioned manifest or whose manifest differs from the candidate.
- Add a changelog fragment.

## Testing

- `python -m pytest policyengine_uk_data/tests/test_release_manifest.py -q` passed locally: 22 passed, 1 skipped because `policyengine-bundles` is not installed locally.
- `ruff check policyengine_uk_data/utils/release_manifest.py policyengine_uk_data/utils/data_upload.py policyengine_uk_data/tests/test_release_manifest.py` passed.
- `ruff format --check policyengine_uk_data/utils/release_manifest.py policyengine_uk_data/utils/data_upload.py policyengine_uk_data/tests/test_release_manifest.py` passed.

## Notes

- This intentionally does not introduce `release-complete.json`; the release manifest is the release contract.
- Local Python 3.14 pytest execution was blocked because this macOS x86_64 environment could not resolve a compatible `torch==2.9.1` wheel through `uv`.