### PR TITLE
Update rail aggregate smoke target

### DIFF
--- a/policyengine_uk_data/tests/test_aggregates.py
+++ b/policyengine_uk_data/tests/test_aggregates.py
@@ -3,7 +3,9 @@ import pytest
 AGGREGATES = {
     "nhs_spending": 200e9,
     # "dfe_education_spending": 70e9,
-    "rail_subsidy_spending": 12e9,
+    # ORR/GOV.UK rail finance statistics report GBP 21.6bn of government
+    # support to the rail industry in 2024-25.
+    "rail_subsidy_spending": 21.6e9,
     # "bus_subsidy_spending": 2.5e9,
 }
 


### PR DESCRIPTION
## Summary
- update the rail subsidy aggregate smoke-test target from £12.0bn to £21.6bn, matching current rail finance statistics
- keep pyproject/changelog untouched so the already-bumped 1.55.5 can be republished by manually dispatching the Push workflow after merge

## Verification
- uv run ruff format --check policyengine_uk_data/tests/test_aggregates.py
- uv run ruff check policyengine_uk_data/tests/test_aggregates.py
- uv run pytest policyengine_uk_data/tests/test_aggregates.py::test_aggregates -q (skips locally because private enhanced FRS is unavailable)