### PR TITLE
Preserve fuel litre proxies in consumption training

### DIFF
--- a/changelog.d/fuel-litre-proxy.changed.md
+++ b/changelog.d/fuel-litre-proxy.changed.md
@@ -1,0 +1,1 @@
+Adjust LCFS petrol and diesel consumption training to preserve fuel-litre proxies using DESNZ pump-price averages, and version the regenerated consumption imputation model filename.

--- a/policyengine_uk_data/datasets/imputations/consumption.py
+++ b/policyengine_uk_data/datasets/imputations/consumption.py
@@ -38,6 +38,21 @@ _HAS_FUEL_SEED = 42
 # EV/ICE vehicle mix from NTS 2024
 NTS_2024_ICE_VEHICLE_SHARE = 0.90
 
+# DESNZ weekly road-fuel price statistics, "Data" sheet, fiscal-year average
+# UK pump prices over 2021-04-01 to 2022-03-31. Data source:
+# https://www.data.gov.uk/dataset/21db6396-3daf-4d90-8b3f-054995256018/petrol-and-diesel-prices
+# LCFS records nominal fuel spending, while PolicyEngine derives litres via
+# ``spending / model pump price``.
+LCFS_FUEL_PRICE_GBP_PER_LITRE = {
+    "petrol_spending": {2021: 1.3890790089424998},
+    "diesel_spending": {2021: 1.4291180616502566},
+}
+FUEL_PRICE_PARAMETER_NAME = {
+    "petrol_spending": "petrol",
+    "diesel_spending": "diesel",
+}
+CONSUMPTION_MODEL_FILENAME = "consumption_fuel_litre_proxy_2026_05.pkl"
+
 REGIONS = {
     1: "NORTH_EAST",
     2: "NORTH_WEST",
@@ -527,17 +542,16 @@ def generate_lcfs_table(lcfs_person: pd.DataFrame, lcfs_household: pd.DataFrame)
 
 def uprate_lcfs_table(household: pd.DataFrame, time_period: str) -> pd.DataFrame:
     from policyengine_uk.system import system
-    from policyengine_uk_data.sources.road_fuel_volume import (
-        road_fuel_volume_uprating,
-    )
 
     start_period = 2021
-    fuel_uprating = road_fuel_volume_uprating(
-        start_year=start_period,
-        end_year=int(str(time_period)[:4]),
-    )
-    household["petrol_spending"] *= fuel_uprating
-    household["diesel_spending"] *= fuel_uprating
+    target_year = int(str(time_period)[:4])
+    for variable in FUEL_PRICE_PARAMETER_NAME:
+        household[variable] *= fuel_spending_litre_proxy_uprating(
+            variable=variable,
+            start_year=start_period,
+            end_year=target_year,
+            parameters=system.parameters,
+        )
 
     cpi = system.parameters.gov.economic_assumptions.indices.obr.consumer_price_index
     cpi_uprating = cpi(time_period) / cpi(start_period)
@@ -566,6 +580,43 @@ def uprate_lcfs_table(household: pd.DataFrame, time_period: str) -> pd.DataFrame
     return household
 
 
+def fuel_spending_litre_proxy_uprating(
+    *,
+    variable: str,
+    start_year: int,
+    end_year: int,
+    parameters=None,
+) -> float:
+    """Uprate LCFS fuel spending to target-year litres at model pump prices."""
+    from policyengine_uk.system import system
+    from policyengine_uk_data.sources.road_fuel_volume import (
+        road_fuel_volume_uprating,
+    )
+
+    if variable not in FUEL_PRICE_PARAMETER_NAME:
+        raise ValueError(f"Unsupported fuel variable: {variable}")
+
+    if parameters is None:
+        parameters = system.parameters
+
+    try:
+        lcfs_price = LCFS_FUEL_PRICE_GBP_PER_LITRE[variable][start_year]
+    except KeyError as exc:
+        raise ValueError(
+            f"Missing LCFS fuel price for {variable} in fiscal year {start_year}"
+        ) from exc
+
+    model_price = getattr(
+        parameters.household.consumption.fuel.prices,
+        FUEL_PRICE_PARAMETER_NAME[variable],
+    )
+    return (
+        road_fuel_volume_uprating(start_year=start_year, end_year=end_year)
+        * model_price(end_year)
+        / lcfs_price
+    )
+
+
 def save_imputation_models():
     from policyengine_uk_data.utils.qrf import QRF
 
@@ -581,15 +632,16 @@ def save_imputation_models():
     household = generate_lcfs_table(lcfs_person, lcfs_household)
     household = uprate_lcfs_table(household, "2024")
     consumption.fit(household[PREDICTOR_VARIABLES], household[IMPUTATIONS])
-    consumption.save(STORAGE_FOLDER / "consumption.pkl")
+    consumption.save(STORAGE_FOLDER / CONSUMPTION_MODEL_FILENAME)
     return consumption
 
 
 def create_consumption_model(overwrite_existing: bool = False):
     from policyengine_uk_data.utils.qrf import QRF
 
-    if (STORAGE_FOLDER / "consumption.pkl").exists() and not overwrite_existing:
-        return QRF(file_path=STORAGE_FOLDER / "consumption.pkl")
+    model_path = STORAGE_FOLDER / CONSUMPTION_MODEL_FILENAME
+    if model_path.exists() and not overwrite_existing:
+        return QRF(file_path=model_path)
     return save_imputation_models()
 
 

--- a/policyengine_uk_data/tests/test_road_fuel_volume_uprating.py
+++ b/policyengine_uk_data/tests/test_road_fuel_volume_uprating.py
@@ -3,7 +3,9 @@
 import pandas as pd
 
 from policyengine_uk_data.datasets.imputations.consumption import (
+    CONSUMPTION_MODEL_FILENAME,
     IMPUTATIONS,
+    fuel_spending_litre_proxy_uprating,
     uprate_lcfs_table,
 )
 from policyengine_uk_data.sources.road_fuel_volume import (
@@ -97,7 +99,7 @@ def test__given_storage_csv__then_fuel_rows_reflect_volume_index():
             assert df.loc[variable, str(year)] == round(expected[year], 3)
 
 
-def test__given_lcfs_training_table__then_fuel_uprating_uses_volume_index():
+def test__given_lcfs_training_table__then_fuel_uprating_preserves_litre_proxy():
     # Given
     household = pd.DataFrame({variable: [1.0] for variable in IMPUTATIONS})
     household["hbai_household_net_income"] = 1.0
@@ -108,12 +110,42 @@ def test__given_lcfs_training_table__then_fuel_uprating_uses_volume_index():
 
     # When
     out = uprate_lcfs_table(household.copy(), "2024")
-    expected = road_fuel_volume_uprating(start_year=2021, end_year=2024)
+    petrol_expected = fuel_spending_litre_proxy_uprating(
+        variable="petrol_spending",
+        start_year=2021,
+        end_year=2024,
+    )
+    diesel_expected = fuel_spending_litre_proxy_uprating(
+        variable="diesel_spending",
+        start_year=2021,
+        end_year=2024,
+    )
+    volume_only = road_fuel_volume_uprating(start_year=2021, end_year=2024)
 
     # Then
-    assert out["petrol_spending"].iloc[0] == expected
-    assert out["diesel_spending"].iloc[0] == expected
-    assert expected != 1.3
+    assert out["petrol_spending"].iloc[0] == petrol_expected
+    assert out["diesel_spending"].iloc[0] == diesel_expected
+    assert petrol_expected > volume_only
+    assert diesel_expected > volume_only
+    assert petrol_expected != 1.3
+
+
+def test__given_fuel_method_change__then_consumption_model_filename_is_versioned():
+    # Then
+    assert CONSUMPTION_MODEL_FILENAME != "consumption.pkl"
+    assert "fuel_litre_proxy" in CONSUMPTION_MODEL_FILENAME
+
+
+def test__given_obr_2027_volume__then_rate_difference_matches_cost_benchmark():
+    # Given
+    road_fuel_bn_litres = road_fuel_clearances_mlitres()[2027] / 1_000
+    broad_2027_rate_gap_gbp_per_litre = FISCAL_YEAR_AVERAGE_DUTY_RATE[2027] - 0.5295
+
+    # When
+    benchmark_cost_gbp_bn = road_fuel_bn_litres * broad_2027_rate_gap_gbp_per_litre
+
+    # Then
+    assert round(benchmark_cost_gbp_bn, 2) == 3.12
 
 
 def test__given_year_after_obr_horizon__then_last_forecast_is_carried_forward():

--- a/policyengine_uk_data/utils/uprating.py
+++ b/policyengine_uk_data/utils/uprating.py
@@ -7,8 +7,8 @@ END_YEAR = 2034
 
 # These variables are named as spending, but PolicyEngine UK currently uses
 # them only to derive fuel litres through ``litres = spending / price``. With
-# pump-price parameters held flat after 2024, CPI uprating turns price growth
-# into litres growth. Use road-fuel volumes instead.
+# pump-price parameters held flat after 2024, price-index uprating turns price
+# growth into litres growth. Use road-fuel volumes instead.
 VOLUME_OVERRIDDEN_VARIABLES = ("petrol_spending", "diesel_spending")
 
 
@@ -61,8 +61,8 @@ def create_policyengine_uprating_factors_table():
     df = df.pivot(index="Variable", columns="Year", values="Value")
     df = df.sort_values("Variable")
 
-    # Override CPI-based uprating for petrol/diesel with sourced road-fuel
-    # clearances. See policyengine_uk_data.sources.road_fuel_volume.
+    # Ensure petrol/diesel use sourced road-fuel clearances. This keeps the
+    # generated CSV aligned with PolicyEngine UK's runtime road-fuel index.
     df = _apply_road_fuel_volume_override(df)
 
     df.to_csv(STORAGE_FOLDER / "uprating_factors.csv")
@@ -79,15 +79,13 @@ def create_policyengine_uprating_factors_table():
 
 
 def _apply_road_fuel_volume_override(df: pd.DataFrame) -> pd.DataFrame:
-    """Replace CPI-based growth for petrol/diesel with a road-fuel volume index.
+    """Set petrol/diesel growth to a sourced road-fuel volume index.
 
-    The default ``uprating`` parameter on ``petrol_spending`` and
-    ``diesel_spending`` in the PolicyEngine UK model is the OBR CPI. Combined
-    with a flat pump-price parameter and ``litres = spending / price`` that
-    implicitly inflates household-level *quantities* by CPI — which is
-    economically wrong. This function substitutes the row with a
-    road-fuel-volume index: HMRC clearances historically and OBR-implied
-    clearances over the forecast.
+    PolicyEngine derives litres as ``spending / price``. With pump-price
+    parameters held flat after 2024, a price index would implicitly become
+    quantity growth. This function writes the road-fuel-volume index used by
+    PolicyEngine UK runtime projection: HMRC clearances historically and
+    OBR-implied clearances over the forecast.
     """
     from policyengine_uk_data.sources.road_fuel_volume import (
         road_fuel_volume_index,


### PR DESCRIPTION
## Summary
- uprate LCFS petrol and diesel training spending as litre proxies: road-fuel volume growth times target model pump price over LCFS pump price
- add DESNZ fiscal-year pump-price constants for LCFS 2021-22
- version the consumption imputation model filename so stale consumption.pkl files are not reused

## Tests
- uv run ruff format policyengine_uk_data/utils/uprating.py policyengine_uk_data/datasets/imputations/consumption.py policyengine_uk_data/tests/test_road_fuel_volume_uprating.py
- uv run ruff check policyengine_uk_data/utils/uprating.py policyengine_uk_data/datasets/imputations/consumption.py policyengine_uk_data/tests/test_road_fuel_volume_uprating.py
- uv run pytest policyengine_uk_data/tests/test_road_fuel_volume_uprating.py -q
- git diff --check