### PR TITLE
Harden Scotland council tax workbook download

### DIFF
--- a/changelog.d/scotland-council-tax-source.fixed.md
+++ b/changelog.d/scotland-council-tax-source.fixed.md
@@ -1,0 +1,1 @@
+Make the Scotland council tax workbook download retry bad responses and fall back to the source page link.

--- a/policyengine_uk_data/targets/sources/voa_council_tax.py
+++ b/policyengine_uk_data/targets/sources/voa_council_tax.py
@@ -10,8 +10,12 @@ Sources:
 """
 
 from functools import lru_cache
+from html import unescape
 from io import BytesIO
 import re
+import time
+from urllib.parse import urljoin
+from zipfile import BadZipFile
 
 import openpyxl
 import requests
@@ -33,6 +37,10 @@ _SCOTLAND_WORKBOOK_URL = (
     "number-of-chargeable-dwellings/chargeable-dwellings---september-2025-data/"
     "chargeable-dwellings---september-2025-data/govscot%3Adocument/"
     "CTAXBASE%2B2025%2B-%2BTables%2B-%2BChargeable%2BDwellings.xlsx"
+)
+_SCOTLAND_WORKBOOK_LINK = re.compile(
+    r'href="([^"]*chargeable-dwellings---september-2025-data[^"]+?\.xlsx)"',
+    re.IGNORECASE,
 )
 _VOA_NAME_TO_REGION = {
     "North East": "NORTH_EAST",
@@ -70,16 +78,70 @@ def _download_workbook() -> openpyxl.Workbook:
     return openpyxl.load_workbook(BytesIO(workbook_response.content), data_only=True)
 
 
-@lru_cache(maxsize=1)
-def _download_scotland_workbook() -> openpyxl.Workbook:
+def _load_xlsx_response(response: requests.Response) -> openpyxl.Workbook:
+    response.raise_for_status()
+    try:
+        return openpyxl.load_workbook(BytesIO(response.content), data_only=True)
+    except BadZipFile as error:
+        content_type = response.headers.get("content-type", "")
+        preview = response.content[:160].decode("utf-8", errors="replace")
+        preview = " ".join(preview.split())
+        raise ValueError(
+            "Expected an XLSX workbook from "
+            f"{response.url}; got content-type {content_type!r} "
+            f"with {len(response.content)} bytes: {preview!r}"
+        ) from error
+
+
+def _scotland_workbook_urls_from_page() -> list[str]:
     r = requests.get(
-        _SCOTLAND_WORKBOOK_URL,
+        _SCOTLAND_REF,
         headers=HEADERS,
         allow_redirects=True,
         timeout=60,
     )
     r.raise_for_status()
-    return openpyxl.load_workbook(BytesIO(r.content), data_only=True)
+    urls: list[str] = []
+    for match in _SCOTLAND_WORKBOOK_LINK.finditer(r.text):
+        url = urljoin(_SCOTLAND_REF, unescape(match.group(1)))
+        if url not in urls:
+            urls.append(url)
+    return urls
+
+
+@lru_cache(maxsize=1)
+def _download_scotland_workbook() -> openpyxl.Workbook:
+    errors: list[str] = []
+
+    def try_url(url: str) -> openpyxl.Workbook | None:
+        for attempt in range(3):
+            try:
+                r = requests.get(
+                    url,
+                    headers=HEADERS,
+                    allow_redirects=True,
+                    timeout=60,
+                )
+                return _load_xlsx_response(r)
+            except Exception as error:
+                errors.append(f"{url}: {error}")
+                if attempt < 2:
+                    time.sleep(2**attempt)
+        return None
+
+    workbook = try_url(_SCOTLAND_WORKBOOK_URL)
+    if workbook is not None:
+        return workbook
+
+    for url in _scotland_workbook_urls_from_page():
+        workbook = try_url(url)
+        if workbook is not None:
+            return workbook
+
+    raise ValueError(
+        "Could not download Scotland council tax workbook. Recent errors: "
+        + " | ".join(errors[-3:])
+    )
 
 
 def _to_float(value) -> float:

--- a/policyengine_uk_data/tests/test_voa_council_tax.py
+++ b/policyengine_uk_data/tests/test_voa_council_tax.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import openpyxl
+import pytest
+
+from policyengine_uk_data.targets.sources import voa_council_tax
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        content: bytes = b"",
+        *,
+        text: str = "",
+        url: str = "https://example.test/file.xlsx",
+        content_type: str = "application/octet-stream",
+    ):
+        self.content = content
+        self.text = text
+        self.url = url
+        self.headers = {"content-type": content_type}
+
+    def raise_for_status(self):
+        return None
+
+
+def _workbook_bytes() -> bytes:
+    workbook = openpyxl.Workbook()
+    worksheet = workbook.active
+    worksheet.title = "Chargeable Dwellings 2025"
+    worksheet.cell(row=8, column=10).value = 2_623_149
+    out = BytesIO()
+    workbook.save(out)
+    return out.getvalue()
+
+
+def test_scotland_workbook_download_falls_back_to_source_page(monkeypatch):
+    voa_council_tax._download_scotland_workbook.cache_clear()
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        if len(calls) <= 3:
+            return DummyResponse(
+                b"<html>temporary bad response</html>",
+                url=url,
+                content_type="text/html",
+            )
+        if url == voa_council_tax._SCOTLAND_REF:
+            return DummyResponse(
+                text=(
+                    '<a href="/binaries/content/documents/govscot/publications/'
+                    "statistics/2019/04/council-tax-datasets/documents/"
+                    "number-of-chargeable-dwellings/"
+                    "chargeable-dwellings---september-2025-data/"
+                    "chargeable-dwellings---september-2025-data/"
+                    "govscot%3Adocument/"
+                    "CTAXBASE%2B2025%2B-%2BTables%2B-%2B"
+                    'Chargeable%2BDwellings.xlsx">download</a>'
+                ),
+                url=url,
+                content_type="text/html",
+            )
+        return DummyResponse(
+            _workbook_bytes(),
+            url=url,
+            content_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+
+    monkeypatch.setattr(voa_council_tax.requests, "get", fake_get)
+    monkeypatch.setattr(voa_council_tax.time, "sleep", lambda _: None)
+
+    workbook = voa_council_tax._download_scotland_workbook()
+
+    assert workbook["Chargeable Dwellings 2025"].cell(row=8, column=10).value == (
+        2_623_149
+    )
+    assert calls[:3] == [voa_council_tax._SCOTLAND_WORKBOOK_URL] * 3
+    assert voa_council_tax._SCOTLAND_REF in calls
+
+
+def test_load_xlsx_response_reports_bad_content_type():
+    with pytest.raises(ValueError, match="Expected an XLSX workbook"):
+        voa_council_tax._load_xlsx_response(
+            DummyResponse(
+                b"<html>not a workbook</html>",
+                content_type="text/html",
+            )
+        )


### PR DESCRIPTION
## Summary
- retry bad Scotland council tax workbook responses
- fall back to the gov.scot source page workbook link
- add regression coverage for non-xlsx responses

## Tests
- env -u UV_FROZEN uv run ruff check policyengine_uk_data/targets/sources/voa_council_tax.py policyengine_uk_data/tests/test_voa_council_tax.py
- env -u UV_FROZEN uv run pytest policyengine_uk_data/tests/test_voa_council_tax.py policyengine_uk_data/tests/test_target_registry.py::test_voa_council_tax_targets -q
- git diff --check