### PR TITLE
Add PIP points from disability categories

### DIFF
--- a/changelog.d/pip-points.md
+++ b/changelog.d/pip-points.md
@@ -1,0 +1,1 @@
+Add category-consistent PIP points imputation for future PIP point-threshold modeling.

--- a/policyengine_uk_data/datasets/disability_benefits.py
+++ b/policyengine_uk_data/datasets/disability_benefits.py
@@ -33,8 +33,15 @@ DISABILITY_CATEGORY_COLUMNS = (
     "pip_dl_category",
 )
 
+PIP_POINT_COLUMNS = (
+    "pip_m_points",
+    "pip_dl_points",
+)
+
 SAFETY_MARGIN = 0.1
 SURVEY_REPORTED_AMOUNT_WEEKS_IN_YEAR = 365.25 / 7
+PIP_STANDARD_POINTS = 8
+PIP_ENHANCED_POINTS = 12
 
 
 @lru_cache(maxsize=None)
@@ -48,6 +55,12 @@ def _dwp_category_threshold_parameters(year: int):
 def _dwp_flag_parameters(year: int):
     # Match the FRS disability flag derivation that already lived in uk-data.
     return CountryTaxBenefitSystem().parameters(year).gov.dwp
+
+
+@lru_cache(maxsize=None)
+def _model_supports_pip_point_inputs() -> bool:
+    variables = CountryTaxBenefitSystem().variables
+    return all(column in variables for column in PIP_POINT_COLUMNS)
 
 
 def _reported_amount(person: pd.DataFrame, column: str) -> pd.Series:
@@ -68,6 +81,44 @@ def _category_from_reported_amount(
             category_name
         )
     return category
+
+
+def _minimum_pip_points_from_category(category: pd.Series) -> np.ndarray:
+    category = category.fillna("NONE").astype(str)
+    return np.select(
+        [
+            category == "ENHANCED",
+            category == "STANDARD",
+        ],
+        [
+            PIP_ENHANCED_POINTS,
+            PIP_STANDARD_POINTS,
+        ],
+        default=0,
+    ).astype(int)
+
+
+def add_pip_points_from_categories(
+    person: pd.DataFrame,
+    *,
+    inplace: bool = False,
+) -> pd.DataFrame:
+    """Assign the minimum PIP points consistent with observed categories."""
+
+    if not inplace:
+        person = person.copy()
+
+    mappings = (
+        ("pip_m_category", "pip_m_points"),
+        ("pip_dl_category", "pip_dl_points"),
+    )
+    for category_column, points_column in mappings:
+        if category_column in person.columns:
+            person[points_column] = _minimum_pip_points_from_category(
+                person[category_column]
+            )
+
+    return person
 
 
 def add_disability_benefit_categories_from_reported_amounts(
@@ -132,6 +183,9 @@ def add_disability_benefit_categories_from_reported_amounts(
                 person[reported_column],
                 thresholds,
             )
+
+    if _model_supports_pip_point_inputs():
+        add_pip_points_from_categories(person, inplace=True)
 
     return person
 

--- a/policyengine_uk_data/tests/test_disability_benefits.py
+++ b/policyengine_uk_data/tests/test_disability_benefits.py
@@ -8,6 +8,7 @@ from policyengine_uk.model_api import WEEKS_IN_YEAR
 from policyengine_uk_data.datasets.disability_benefits import (
     add_disability_benefit_categories_from_reported_amounts,
     add_disability_benefit_flags_from_reported_amounts,
+    add_pip_points_from_categories,
     drop_internal_disability_reported_amounts,
     strip_internal_disability_reported_amounts,
 )
@@ -53,6 +54,22 @@ def test_reported_amounts_map_to_disability_categories():
     assert result["dla_m_category"].tolist() == ["NONE", "LOWER", "HIGHER"]
     assert result["pip_m_category"].tolist() == ["NONE", "STANDARD", "ENHANCED"]
     assert result["pip_dl_category"].tolist() == ["NONE", "STANDARD", "ENHANCED"]
+
+
+def test_pip_categories_map_to_minimum_qualifying_points():
+    person = pd.DataFrame(
+        {
+            "pip_m_category": ["NONE", "STANDARD", "ENHANCED", None],
+            "pip_dl_category": ["ENHANCED", "STANDARD", "NONE", None],
+        }
+    )
+
+    result = add_pip_points_from_categories(person)
+
+    assert result["pip_m_points"].tolist() == [0, 8, 12, 0]
+    assert result["pip_dl_points"].tolist() == [12, 8, 0, 0]
+    assert "pip_m_points" not in person.columns
+    assert "pip_dl_points" not in person.columns
 
 
 def test_reported_amounts_recompute_disability_flags():


### PR DESCRIPTION
## Summary
- add a dataset-side helper assigning minimum qualifying PIP points from PIP daily living and mobility categories
- guard automatic population of `pip_dl_points` / `pip_m_points` until the active `policyengine-uk` dependency exposes those input variables
- add unit coverage for the category-to-points mapping

## Context
Companion to PolicyEngine/policyengine-uk#1661. UK data currently assigns `pip_dl_category` and `pip_m_category` from reported amounts; this PR provides a conservative category-consistent points imputation so #1661's point-threshold formulas can be data-backed once those variables exist in `policyengine-uk`.

## Tests
- `uv run pytest policyengine_uk_data/tests/test_disability_benefits.py -q`
- `uv run --python 3.13 pytest policyengine_uk_data/tests/test_disability_benefits.py -q`
