### PR TITLE
Widen disability benefit flags from reported amounts

### DIFF
--- a/policyengine_uk_data/datasets/disability_benefits.py
+++ b/policyengine_uk_data/datasets/disability_benefits.py
@@ -33,6 +33,20 @@ DISABILITY_CATEGORY_COLUMNS = (
     "pip_dl_category",
 )
 
+BASE_DISABILITY_FLAG_REPORTED_AMOUNT_COLUMNS = (
+    "attendance_allowance_reported",
+    "dla_sc_reported",
+    "dla_m_reported",
+    "pip_m_reported",
+    "pip_dl_reported",
+    "sda_reported",
+    "incapacity_benefit_reported",
+    "iidb_reported",
+    "afcs_reported",
+    "esa_contrib_reported",
+    "esa_income_reported",
+)
+
 SAFETY_MARGIN = 0.1
 SURVEY_REPORTED_AMOUNT_WEEKS_IN_YEAR = 365.25 / 7
 
@@ -54,6 +68,16 @@ def _reported_amount(person: pd.DataFrame, column: str) -> pd.Series:
     if column not in person.columns:
         return pd.Series(0.0, index=person.index)
     return pd.to_numeric(person[column], errors="coerce").fillna(0.0)
+
+
+def _reported_amount_sum(
+    person: pd.DataFrame,
+    columns: tuple[str, ...],
+) -> pd.Series:
+    total = pd.Series(0.0, index=person.index)
+    for column in columns:
+        total += _reported_amount(person, column)
+    return total
 
 
 def _category_from_reported_amount(
@@ -148,15 +172,20 @@ def add_disability_benefit_flags_from_reported_amounts(
         person = person.copy()
 
     dwp = _dwp_flag_parameters(int(year))
+    attendance_allowance = _reported_amount(person, "attendance_allowance_reported")
     dla_sc = _reported_amount(person, "dla_sc_reported")
-    dla_m = _reported_amount(person, "dla_m_reported")
-    pip_m = _reported_amount(person, "pip_m_reported")
     pip_dl = _reported_amount(person, "pip_dl_reported")
     afcs = _reported_amount(person, "afcs_reported")
 
-    person["is_disabled_for_benefits"] = (dla_sc + dla_m + pip_m + pip_dl) > 0
+    person["is_disabled_for_benefits"] = (
+        _reported_amount_sum(person, BASE_DISABILITY_FLAG_REPORTED_AMOUNT_COLUMNS) > 0
+    )
 
     threshold_safety_gap = 1 * SURVEY_REPORTED_AMOUNT_WEEKS_IN_YEAR
+    aa_higher = (
+        dwp.attendance_allowance.higher * SURVEY_REPORTED_AMOUNT_WEEKS_IN_YEAR
+        - threshold_safety_gap
+    )
     dla_sc_higher = (
         dwp.dla.self_care.higher * SURVEY_REPORTED_AMOUNT_WEEKS_IN_YEAR
         - threshold_safety_gap
@@ -166,9 +195,16 @@ def add_disability_benefit_flags_from_reported_amounts(
         - threshold_safety_gap
     )
 
-    person["is_enhanced_disabled_for_benefits"] = dla_sc > dla_sc_higher
+    person["is_enhanced_disabled_for_benefits"] = (
+        (attendance_allowance >= aa_higher)
+        | (dla_sc > dla_sc_higher)
+        | (pip_dl >= pip_dl_enhanced)
+    )
     person["is_severely_disabled_for_benefits"] = (
-        (dla_sc >= dla_sc_higher) | (pip_dl >= pip_dl_enhanced) | (afcs > 0)
+        (attendance_allowance > 0)
+        | (dla_sc >= dla_sc_higher)
+        | (pip_dl >= pip_dl_enhanced)
+        | (afcs > 0)
     )
 
     return person

--- a/policyengine_uk_data/tests/test_disability_benefits.py
+++ b/policyengine_uk_data/tests/test_disability_benefits.py
@@ -60,6 +60,7 @@ def test_reported_amounts_recompute_disability_flags():
     dwp = CountryTaxBenefitSystem().parameters(year).gov.dwp
     person = pd.DataFrame(
         {
+            "attendance_allowance_reported": [0.0, 0.0, 0.0],
             "dla_sc_reported": [
                 0.0,
                 dwp.dla.self_care.higher * (365.25 / 7),
@@ -85,13 +86,52 @@ def test_reported_amounts_recompute_disability_flags():
     assert result["is_enhanced_disabled_for_benefits"].tolist() == [
         False,
         True,
-        False,
+        True,
     ]
     assert result["is_severely_disabled_for_benefits"].tolist() == [
         False,
         True,
         True,
     ]
+
+
+def test_reported_amounts_widen_base_disability_flag():
+    year = 2025
+    person = pd.DataFrame(
+        {
+            "attendance_allowance_reported": [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "sda_reported": [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "incapacity_benefit_reported": [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            "iidb_reported": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            "afcs_reported": [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            "esa_contrib_reported": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            "esa_income_reported": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        }
+    )
+
+    result = add_disability_benefit_flags_from_reported_amounts(person, year)
+
+    assert result["is_disabled_for_benefits"].all()
+
+
+def test_attendance_allowance_feeds_stronger_disability_flags():
+    year = 2025
+    dwp = CountryTaxBenefitSystem().parameters(year).gov.dwp
+    weeks = 365.25 / 7
+    person = pd.DataFrame(
+        {
+            "attendance_allowance_reported": [
+                dwp.attendance_allowance.lower * weeks,
+                dwp.attendance_allowance.higher * weeks,
+            ],
+        }
+    )
+
+    result = add_disability_benefit_flags_from_reported_amounts(person, year)
+
+    assert result["is_disabled_for_benefits"].tolist() == [True, True]
+    assert result["is_enhanced_disabled_for_benefits"].tolist() == [False, True]
+    assert result["is_severely_disabled_for_benefits"].tolist() == [True, True]
 
 
 def test_drop_internal_disability_reported_amounts_keeps_categories():


### PR DESCRIPTION
## Summary
- widen `is_disabled_for_benefits` to include AA, SDA, incapacity benefit, IIDB, AFCS, and ESA reported amounts
- treat Attendance Allowance as a severe-disability signal, and higher-rate AA as an enhanced-disability signal
- update focused disability-benefit tests for the wider base flag and AA-derived stronger flags

Closes #400

## Tests
- `uv run --python 3.13 --frozen ruff format --check policyengine_uk_data/datasets/disability_benefits.py policyengine_uk_data/tests/test_disability_benefits.py`
- `uv run --python 3.13 --frozen ruff check policyengine_uk_data/datasets/disability_benefits.py policyengine_uk_data/tests/test_disability_benefits.py`
- `uv run --python 3.13 --frozen pytest policyengine_uk_data/tests/test_disability_benefits.py policyengine_uk_data/tests/test_frs_only_imputation.py::test_frs_only_recomputes_disability_flags_after_amount_imputation -q`
- `git diff --check`