### PR TITLE
Impute mortgage and consumer debt from the Wealth and Assets Survey

### DIFF
--- a/changelog.d/mortgage-consumer-debt-imputation.added.md
+++ b/changelog.d/mortgage-consumer-debt-imputation.added.md
@@ -1,0 +1,1 @@
+Impute household `mortgage_debt` (gross outstanding mortgage debt, WAS `HMortGR8`) and `consumer_debt` (non-mortgage, non-student-loan borrowing) from the Wealth and Assets Survey, enabling a net wealth measure that can be negative for households whose debts exceed their assets.

--- a/policyengine_uk_data/datasets/imputations/wealth.py
+++ b/policyengine_uk_data/datasets/imputations/wealth.py
@@ -97,6 +97,7 @@ WAS_RENAMES = {
     # Other columns for reference.
     "DVLOSValR8_sum": "non_uk_land",
     "HFINWNTR8_Sum": "net_financial_wealth",
+    "HFINWNTR8_exSLC_Sum": "net_financial_wealth_exsl",  # net of all debt but SLC
     "DVLUKDebtR8_sum": "uk_land_debt",
     "HMortGR8": "mortgage_debt",  # gross outstanding household mortgage debt
     "HFINWR8_SUM": "gross_financial_wealth",
@@ -163,8 +164,14 @@ def generate_was_table(was: pd.DataFrame):
         ]
     ].sum(axis=1)
     was["student_loan_balance"] = was["total_loans"] - was["total_loans_exc_slc"]
-    # Non-mortgage, non-student-loan borrowing (personal loans, credit, etc.).
-    was["consumer_debt"] = was["total_loans_exc_slc"]
+    # All non-mortgage, non-student-loan financial liabilities: personal and
+    # informal loans, credit and store cards, overdrafts, hire purchase, and
+    # arrears. WAS does not itemise these on the household file, but they are the
+    # gap between gross financial wealth and financial wealth netted of every
+    # liability except student loans. Captures far more than formal loans alone.
+    was["consumer_debt"] = (
+        was["gross_financial_wealth"] - was["net_financial_wealth_exsl"]
+    ).clip(lower=0)
     was["region"] = was["region"].map(REGIONS)
     return was
 

--- a/policyengine_uk_data/datasets/imputations/wealth.py
+++ b/policyengine_uk_data/datasets/imputations/wealth.py
@@ -57,7 +57,16 @@ IMPUTE_VARIABLES = [
     "savings",
     "num_vehicles",
     "student_loan_balance",
+    # Liabilities, so a net wealth measure can go negative for households whose
+    # debts exceed their assets. mortgage_debt is gross outstanding household
+    # mortgage debt (WAS HMortGR8); consumer_debt is non-mortgage,
+    # non-student-loan borrowing (personal loans, credit, hire purchase).
+    "mortgage_debt",
+    "consumer_debt",
 ]
+
+# Imputed liabilities, clipped at zero on write (a debt cannot be negative).
+DEBT_COLUMNS = {"mortgage_debt", "consumer_debt"}
 
 WAS_RENAMES = {
     "R8xshhwgt": "household_weight",
@@ -89,6 +98,7 @@ WAS_RENAMES = {
     "DVLOSValR8_sum": "non_uk_land",
     "HFINWNTR8_Sum": "net_financial_wealth",
     "DVLUKDebtR8_sum": "uk_land_debt",
+    "HMortGR8": "mortgage_debt",  # gross outstanding household mortgage debt
     "HFINWR8_SUM": "gross_financial_wealth",
     "TotalWlthR8": "wealth",
     "DVhvalueR8": "main_residence_value",
@@ -153,6 +163,8 @@ def generate_was_table(was: pd.DataFrame):
         ]
     ].sum(axis=1)
     was["student_loan_balance"] = was["total_loans"] - was["total_loans_exc_slc"]
+    # Non-mortgage, non-student-loan borrowing (personal loans, credit, etc.).
+    was["consumer_debt"] = was["total_loans_exc_slc"]
     was["region"] = was["region"].map(REGIONS)
     return was
 
@@ -347,7 +359,10 @@ def impute_wealth(dataset: UKSingleYearDataset) -> UKSingleYearDataset:
                 person=dataset.person,
             )
             continue
-        dataset.household[column] = output_df[column].values
+        values = output_df[column]
+        if column in DEBT_COLUMNS:
+            values = values.clip(lower=0)  # a liability cannot be negative
+        dataset.household[column] = values.values
 
     dataset.validate()
 


### PR DESCRIPTION
## What

Imputes two household liabilities from the Wealth and Assets Survey (Round 8) alongside the existing wealth components:

- `mortgage_debt` — gross outstanding household mortgage debt (WAS `HMortGR8`; ~30% of households, ~£44k mean).
- `consumer_debt` — non-mortgage, non-student-loan borrowing (personal loans, credit, hire purchase).

Both are clipped at zero on write (a liability cannot be negative).

## Why

`total_wealth` is gross (property + corporate + savings) with no liabilities netted out, so it can never be negative. The bottom of the wealth distribution is therefore an artefact — ~13% of households own nothing and sit at exactly £0, leaving the lowest wealth decile empty. With mortgage and consumer debt imputed, a companion **policyengine-uk** PR adds a `net_wealth` variable that goes negative for genuinely underwater households, putting them at the bottom of the distribution where they belong.

## Notes

`uk_land_debt` (already in the rename map) turned out to be a tiny residual land-debt category (0.2% of households); the real mortgage measure is `HMortGR8`, which this PR uses.
