### PR TITLE
Fix silently-dropped OBR receipts targets (sheet 3.9 is APD, not current receipts)

### DIFF
--- a/policyengine_uk_data/targets/sources/obr.py
+++ b/policyengine_uk_data/targets/sources/obr.py
@@ -103,8 +103,7 @@ def _find_receipts_sheet(wb):
         if title and "current receipts" in str(title).lower():
             return wb[name]
     raise ValueError(
-        "OBR receipts: no worksheet titled 'Current receipts' found in "
-        f"{wb.sheetnames}"
+        f"OBR receipts: no worksheet titled 'Current receipts' found in {wb.sheetnames}"
     )
 
 

--- a/policyengine_uk_data/targets/sources/obr.py
+++ b/policyengine_uk_data/targets/sources/obr.py
@@ -97,13 +97,35 @@ def _find_receipts_sheet(wb):
     EFO releases renumber their tables between vintages. Referring to a sheet by
     number means a renumbering turns every lookup on it into a silent no-op, so
     the sheet is matched on its title instead.
+
+    Several sheets mention "receipts" (e.g. "Other receipts", "Property
+    transactions taxes: Receipts by sector"), so the match is on the full
+    "current receipts" phrase. If a future vintage makes that ambiguous, prefer
+    the cash-basis sheet and otherwise raise rather than silently taking
+    whichever happens to come first.
     """
-    for name in wb.sheetnames:
-        title = wb[name].cell(row=2, column=2).value
-        if title and "current receipts" in str(title).lower():
-            return wb[name]
+    matches = [
+        name
+        for name in wb.sheetnames
+        if (title := wb[name].cell(row=2, column=2).value)
+        and "current receipts" in str(title).lower()
+    ]
+    if not matches:
+        raise ValueError(
+            f"OBR receipts: no worksheet titled 'Current receipts' found in {wb.sheetnames}"
+        )
+    if len(matches) == 1:
+        return wb[matches[0]]
+    cash = [
+        name
+        for name in matches
+        if "cash" in str(wb[name].cell(row=2, column=2).value).lower()
+    ]
+    if len(cash) == 1:
+        return wb[cash[0]]
     raise ValueError(
-        f"OBR receipts: no worksheet titled 'Current receipts' found in {wb.sheetnames}"
+        "OBR receipts: could not identify a single current-receipts sheet; "
+        f"candidates were {matches}. Refusing to guess."
     )
 
 
@@ -120,8 +142,9 @@ def _parse_receipts(wb: openpyxl.Workbook) -> list[Target]:
     """Parse tax receipts from the OBR EFO.
 
     Income tax uses Table 3.4 (accrued basis) for consistency with
-    the standard fiscal forecasting convention. Other receipts use
-    Table 3.9 (cash basis) since they only appear there.
+    the standard fiscal forecasting convention. Other receipts use the
+    current-receipts table (cash basis) since they only appear there; that
+    table is located by title because EFO vintages renumber the sheets.
     """
     config = load_config()
     vintage = config["obr"]["vintage"]
@@ -186,12 +209,13 @@ def _parse_receipts(wb: openpyxl.Workbook) -> list[Target]:
         "sdlt": ("Stamp duty land tax", "stamp_duty_land_tax"),
     }
 
-    missing: list[str] = []
+    recovered: list[str] = []
     for name, (label, variable) in cash_rows.items():
         try:
             row_num = _find_row(ws39, label, col="B", max_row=80)
             values = read_39(ws39, row_num)
             if values:
+                recovered.append(label)
                 targets.append(
                     Target(
                         name=f"obr/{name}",
@@ -205,14 +229,16 @@ def _parse_receipts(wb: openpyxl.Workbook) -> list[Target]:
                 )
         except ValueError:
             logger.warning("OBR receipts: row '%s' not found", label)
-            missing.append(label)
 
-    if len(missing) == len(cash_rows):
+    # Guard on targets actually produced, not on exceptions caught: a layout
+    # change that shifts the value columns finds every row and still yields
+    # nothing, which is the same silent failure by a different route.
+    if not recovered:
         raise ValueError(
             "OBR receipts: none of the cash-basis rows "
-            f"({', '.join(cash_rows[k][0] for k in cash_rows)}) were found on "
-            f"sheet '{ws39.title}'. The EFO layout has probably changed again; "
-            "silently dropping every receipts target is never correct."
+            f"({', '.join(cash_rows[k][0] for k in cash_rows)}) produced values "
+            f"on sheet '{ws39.title}'. The EFO layout has probably changed "
+            "again; silently dropping every receipts target is never correct."
         )
 
     return targets

--- a/policyengine_uk_data/targets/sources/obr.py
+++ b/policyengine_uk_data/targets/sources/obr.py
@@ -91,6 +91,23 @@ def _read_row_values(ws, row_num: int, col_letters: list[str]) -> dict[int, floa
     return result
 
 
+def _find_receipts_sheet(wb):
+    """Return the current-receipts worksheet, located by title.
+
+    EFO releases renumber their tables between vintages. Referring to a sheet by
+    number means a renumbering turns every lookup on it into a silent no-op, so
+    the sheet is matched on its title instead.
+    """
+    for name in wb.sheetnames:
+        title = wb[name].cell(row=2, column=2).value
+        if title and "current receipts" in str(title).lower():
+            return wb[name]
+    raise ValueError(
+        "OBR receipts: no worksheet titled 'Current receipts' found in "
+        f"{wb.sheetnames}"
+    )
+
+
 def _find_row(ws, label: str, col: str = "B", max_row: int = 80) -> int:
     """Find the row number where a cell starts with label."""
     for row in range(1, max_row + 1):
@@ -157,8 +174,11 @@ def _parse_receipts(wb: openpyxl.Workbook) -> list[Target]:
     except ValueError:
         logger.warning("OBR receipts: income tax row not found in 3.4")
 
-    # Other receipts from Table 3.9 (cash basis)
-    ws39 = wb["3.9"]
+    # Other receipts from the current-receipts table (cash basis). The sheet is
+    # located by title rather than number: EFO vintages renumber the tables, and
+    # in March 2026 current receipts moved to 3.8 while 3.9 became the APD
+    # forecast, which silently yielded no targets at all.
+    ws39 = _find_receipts_sheet(wb)
     cash_rows = {
         "ni": ("National insurance contributions", "ni_employee"),
         "vat": ("Value added tax", "vat"),
@@ -167,6 +187,7 @@ def _parse_receipts(wb: openpyxl.Workbook) -> list[Target]:
         "sdlt": ("Stamp duty land tax", "stamp_duty_land_tax"),
     }
 
+    missing: list[str] = []
     for name, (label, variable) in cash_rows.items():
         try:
             row_num = _find_row(ws39, label, col="B", max_row=80)
@@ -185,6 +206,15 @@ def _parse_receipts(wb: openpyxl.Workbook) -> list[Target]:
                 )
         except ValueError:
             logger.warning("OBR receipts: row '%s' not found", label)
+            missing.append(label)
+
+    if len(missing) == len(cash_rows):
+        raise ValueError(
+            "OBR receipts: none of the cash-basis rows "
+            f"({', '.join(cash_rows[k][0] for k in cash_rows)}) were found on "
+            f"sheet '{ws39.title}'. The EFO layout has probably changed again; "
+            "silently dropping every receipts target is never correct."
+        )
 
     return targets
 

--- a/policyengine_uk_data/tests/test_obr_receipts_sheet.py
+++ b/policyengine_uk_data/tests/test_obr_receipts_sheet.py
@@ -14,7 +14,10 @@ silent drop.
 import openpyxl
 import pytest
 
-from policyengine_uk_data.targets.sources.obr import _find_receipts_sheet
+from policyengine_uk_data.targets.sources.obr import (
+    _find_receipts_sheet,
+    _parse_receipts,
+)
 
 
 def _wb(sheets: dict[str, str]) -> openpyxl.Workbook:
@@ -49,8 +52,82 @@ def test_finds_receipts_sheet_after_renumbering():
     assert _find_receipts_sheet(wb).title == "3.11"
 
 
+def test_prefers_cash_basis_when_title_is_ambiguous():
+    """Several sheets mention receipts; the cash-basis one is the right table."""
+    wb = _wb(
+        {
+            "3.4": "3.4 Current receipts (accrued basis)",
+            "3.8": "3.8 Current receipts (on a cash basis)",
+        }
+    )
+    assert _find_receipts_sheet(wb).title == "3.8"
+
+
+def test_raises_rather_than_guessing_when_ambiguous():
+    """Two indistinguishable candidates must fail loudly, not pick the first."""
+    wb = _wb(
+        {
+            "3.8": "3.8 Current receipts (one)",
+            "3.9": "3.9 Current receipts (two)",
+        }
+    )
+    with pytest.raises(ValueError, match="Refusing to guess"):
+        _find_receipts_sheet(wb)
+
+
 def test_raises_when_no_receipts_sheet():
     """Missing the table must fail loudly rather than yield zero targets."""
     wb = _wb({"3.9": "3.9 APD forecast"})
     with pytest.raises(ValueError, match="Current receipts"):
         _find_receipts_sheet(wb)
+
+
+def _receipts_wb(*, populate: bool) -> openpyxl.Workbook:
+    """A current-receipts sheet carrying every label, optionally with values."""
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+    # 3.4 (income tax, accrued basis) is read unconditionally; a missing sheet
+    # raises KeyError rather than the ValueError the parser catches.
+    wb.create_sheet("3.4")["B2"] = "3.4 Income tax (accrued basis)"
+    ws = wb.create_sheet("3.8")
+    ws["B2"] = "3.8 Current receipts (on a cash basis)"
+    labels = [
+        "National insurance contributions",
+        "Value added tax",
+        "Fuel duties",
+        "Capital gains tax",
+        "Stamp duty land tax",
+    ]
+    for offset, label in enumerate(labels):
+        row = 10 + offset
+        ws[f"B{row}"] = label
+        if populate:
+            for col in ("D", "E", "F", "G", "H", "I", "J"):
+                ws[f"{col}{row}"] = 1.0
+    return wb
+
+
+def test_raises_when_rows_are_found_but_yield_no_values(monkeypatch):
+    """A column shift finds every label and still produces nothing.
+
+    The guard must key on targets produced, not on exceptions caught, or this
+    reproduces the silent drop by a different route.
+    """
+    monkeypatch.setattr(
+        "policyengine_uk_data.targets.sources.obr.load_config",
+        lambda: {"obr": {"vintage": "test", "efo_receipts": "https://example.invalid"}},
+    )
+    with pytest.raises(ValueError, match="produced values"):
+        _parse_receipts(_receipts_wb(populate=False))
+
+
+def test_parses_rows_when_values_are_present(monkeypatch):
+    """The same sheet with values yields one target per cash-basis row."""
+    monkeypatch.setattr(
+        "policyengine_uk_data.targets.sources.obr.load_config",
+        lambda: {"obr": {"vintage": "test", "efo_receipts": "https://example.invalid"}},
+    )
+    targets = _parse_receipts(_receipts_wb(populate=True))
+    names = {target.name for target in targets}
+    assert "obr/capital_gains_tax" in names
+    assert len(names) == 5

--- a/policyengine_uk_data/tests/test_obr_receipts_sheet.py
+++ b/policyengine_uk_data/tests/test_obr_receipts_sheet.py
@@ -1,0 +1,56 @@
+"""Tests for locating the OBR current-receipts table.
+
+EFO releases renumber their worksheets between vintages. The cash-basis
+receipts rows (NICs, VAT, fuel duties, capital gains tax, SDLT) were read from
+a hard-coded sheet "3.9", but in the March 2026 tables current receipts sit on
+3.8 and 3.9 is the APD forecast. Every lookup therefore raised, was caught, and
+logged a warning — so all five targets vanished from the calibration surface
+without failing anything.
+
+These tests pin the title-based lookup and the loud failure that replaces the
+silent drop.
+"""
+
+import openpyxl
+import pytest
+
+from policyengine_uk_data.targets.sources.obr import _find_receipts_sheet
+
+
+def _wb(sheets: dict[str, str]) -> openpyxl.Workbook:
+    """Build a workbook whose sheets carry their EFO title in cell B2."""
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+    for name, title in sheets.items():
+        ws = wb.create_sheet(name)
+        ws["B2"] = title
+    return wb
+
+
+def test_finds_receipts_sheet_by_title_not_number():
+    """The March 2026 layout: receipts on 3.8, APD on 3.9."""
+    wb = _wb(
+        {
+            "3.8": "3.8 Current receipts (on a cash basis)",
+            "3.9": "3.9 APD forecast - projection of passenger numbers",
+        }
+    )
+    assert _find_receipts_sheet(wb).title == "3.8"
+
+
+def test_finds_receipts_sheet_after_renumbering():
+    """A future vintage may move the table again; the title still finds it."""
+    wb = _wb(
+        {
+            "3.9": "3.9 Some other forecast",
+            "3.11": "3.11 Current receipts (on a cash basis)",
+        }
+    )
+    assert _find_receipts_sheet(wb).title == "3.11"
+
+
+def test_raises_when_no_receipts_sheet():
+    """Missing the table must fail loudly rather than yield zero targets."""
+    wb = _wb({"3.9": "3.9 APD forecast"})
+    with pytest.raises(ValueError, match="Current receipts"):
+        _find_receipts_sheet(wb)


### PR DESCRIPTION
## Problem

`_parse_receipts` reads the cash-basis receipts rows from a hard-coded worksheet `"3.9"`:

```python
ws39 = wb["3.9"]
cash_rows = {
    "ni": ("National insurance contributions", "ni_employee"),
    "vat": ("Value added tax", "vat"),
    "fuel_duties": ("Fuel duties", "fuel_duty"),
    "capital_gains_tax": ("Capital gains tax", "capital_gains_tax"),
    "sdlt": ("Stamp duty land tax", "stamp_duty_land_tax"),
}
```

In the March 2026 EFO tables — the vintage currently configured in `sources.yaml` — sheet **3.8** is "Current receipts (on a cash basis)" and sheet **3.9** is "APD forecast - projection of passenger numbers". None of the five labels exist on 3.9, so every `_find_row` call raises `ValueError`, is caught, logs a warning, and appends no target.

The result is that **all five cash-basis receipts targets are missing from the calibration surface** — NICs, VAT, fuel duties, capital gains tax and SDLT — with nothing failing. Verified against the configured workbook:

| Label | Sheet 3.8 | Sheet 3.9 |
|---|---|---|
| National insurance contributions | row 12 | not found |
| Value added tax | row 13 | not found |
| Fuel duties | row 21 | not found |
| Capital gains tax | row 22 | not found |
| Stamp duty land tax | row 24 | not found |

Note the existing `cols_39`/`fy_39` column mapping (`D`→2024-25 … `J`→2030-31) already matches 3.8's layout exactly, which suggests the code was written against 3.8 and the sheet was renumbered by a later vintage without the reference being updated.

## Fix

1. Locate the worksheet by **title** (`"current receipts"` in cell B2) rather than by number, so a future renumbering cannot silently repeat this.
2. Raise if *none* of the five rows are found. A per-row warning is right when one label changes; producing zero receipts targets is never a correct outcome and should not pass quietly.

## Verification

Against the March 2026 receipts workbook the fix resolves sheet 3.8 and recovers all five rows (2026-27, £bn):

```
National insurance contributions   210.45
Value added tax                    187.70
Fuel duties                         24.63
Capital gains tax                   20.80
Stamp duty land tax                 18.15
```

Three unit tests cover the March 2026 layout, a hypothetical future renumbering, and the loud-failure path.

## Why I noticed

Capital gains came up in a CGT reform analysis: the Enhanced FRS baseline produces ~1.29m CGT taxpayers holding £112bn of gains against HMRC's 378k and £66bn, and CGT revenue of ~£25bn against the OBR's £20.8bn forecast for 2026-27. Tracing why the OBR figure wasn't constraining the calibration led here. Restoring this target should pull CGT revenue toward the forecast directly.

Separately, `populace` has no capital gains targets at all in its UK surface — PolicyEngine/populace#459 — so gains totals and taxpayer counts remain unconstrained even with this fixed. The two are complementary: this PR restores the OBR *revenue* target; that issue is about HMRC *gains and taxpayer* targets.
