### PR TITLE
Add HMRC capital gains targets to constrain the gains distribution

### DIFF
--- a/changelog.d/hmrc-cgt-targets.md
+++ b/changelog.d/hmrc-cgt-targets.md
@@ -1,0 +1,1 @@
+- Add HMRC capital gains calibration targets (`hmrc/capital_gains_total`, `hmrc/cgt_taxpayers`) so the calibration constrains the distribution of gains, not just CGT revenue. Both apply an annual-exempt-amount gate that tracks the policy year, matching HMRC's CGT-taxpayer concept.

--- a/policyengine_uk_data/targets/sources.yaml
+++ b/policyengine_uk_data/targets/sources.yaml
@@ -10,6 +10,7 @@ hmrc:
   spi_collated: "https://assets.publishing.service.gov.uk/media/69f1f12d2fae53a03709682f/Collated_Tables_3_1_to_3_11_2324.ods"
   spi_geography: "https://assets.publishing.service.gov.uk/media/69f1f17cc42061e837e3ac3b/Collated_Tables_3_12_to_3_15a_2324.ods"
   income_tax_liabilities: "https://www.gov.uk/government/statistics/income-tax-liabilities-statistics-tax-year-2022-to-2023-to-tax-year-2025-to-2026"
+  capital_gains_statistics: "https://www.gov.uk/government/statistics/capital-gains-tax-statistics"
   salary_sacrifice_table_6: "https://assets.publishing.service.gov.uk/media/687a294e312ee8a5f0806b6d/Tables_6_1_and_6_2.csv"
 
 dwp:

--- a/policyengine_uk_data/targets/sources/hmrc_cgt.py
+++ b/policyengine_uk_data/targets/sources/hmrc_cgt.py
@@ -1,0 +1,177 @@
+"""HMRC capital gains targets.
+
+The Enhanced FRS imputes capital gains, but nothing in the calibration
+constrains how those gains are *distributed* across households. Measured
+on the stock weights for 2026, the microdata carries 1.29m CGT taxpayers
+holding £112bn of gains (an £87,158 mean) against HMRC's 378k taxpayers,
+£65.9bn and a ~£174,000 mean: 3.4x too many taxpayers, each holding a
+gain about half the administrative average. That is a distributional
+error, not a level shift, so a revenue target cannot fix it.
+
+Two targets are added:
+
+* ``hmrc/capital_gains_total`` — total chargeable gains of CGT taxpayers.
+* ``hmrc/cgt_taxpayers`` — the number of CGT taxpayers.
+
+Both use a ``custom_compute``. The default count path in
+``build_loss_matrix._compute_simple_count`` counts people with
+``capital_gains > 0``, which is not HMRC's concept: HMRC counts CGT
+*taxpayers*, i.e. people whose gains exceed the annual exempt amount
+(AEA). The amount target is gated on the same AEA condition, for the
+same reason — HMRC's £65.9bn is the gains of CGT-liable taxpayers, not
+all gains realised in the economy. Gating only the count and leaving the
+amount ungated would target a mean gain that is a ratio of two different
+populations, and would let the optimiser satisfy the amount with
+sub-threshold gains that HMRC never counts.
+
+The AEA is policy-dependent (£12,300 for 2022-23, £6,000 for 2023-24,
+£3,000 from 2024-25) and is read from PolicyEngine's own parameter tree
+for the simulation year, so the target's meaning tracks the policy in
+force. ``_AEA_FALLBACK`` is used only if the parameter lookup fails.
+
+Year handling: HMRC's figures are the 2023-24 outturn, mapped to
+calendar 2024 following ``hmrc_spi._SPI_YEAR``. The amount is projected
+to 2029 with PolicyEngine's ``capital_gains`` uprating factors so the
+target constrains the projection years the calibration actually runs
+for; the taxpayer count is held flat, as the repo has no administrative
+basis for forecasting CGT taxpayer numbers and count uprating factors
+would be a nominal-income index applied to a headcount.
+
+Caveat: the 2023-24 outturn was realised under a £6,000 AEA, while the
+gate applied in later years uses the £3,000 AEA then in force. The
+targets are therefore approximate for the projection years; the
+alternative (a fixed £6,000 gate) would be wrong in a different and less
+transparent way, because it would not describe any year's actual policy.
+
+Source: https://www.gov.uk/government/statistics/capital-gains-tax-statistics
+"""
+
+import logging
+
+import numpy as np
+
+from policyengine_uk_data.targets.schema import Target, Unit
+from policyengine_uk_data.targets.sources._common import load_config
+
+logger = logging.getLogger(__name__)
+
+# HMRC CGT statistics, tax year 2023-24 outturn, mapped to calendar 2024
+# following the hmrc_spi._SPI_YEAR convention.
+_CGT_BASE_YEAR = 2024
+_MAX_YEAR = 2029
+
+# Total chargeable gains of CGT taxpayers, 2023-24 (£65.9bn).
+_CGT_TOTAL_GAINS = 65.9e9
+# Number of CGT taxpayers, 2023-24.
+_CGT_TAXPAYERS = 378_000
+
+# Annual exempt amount by tax year start, used only if the PolicyEngine
+# parameter lookup fails.
+_AEA_FALLBACK = {
+    2022: 12_300,
+    2023: 6_000,
+}
+_AEA_FALLBACK_DEFAULT = 3_000
+
+_PARAMETER_PATH = "gov.hmrc.cgt.annual_exempt_amount"
+
+
+def _annual_exempt_amount(ctx, year: int) -> float:
+    """Annual exempt amount in force in ``year``.
+
+    Read from PolicyEngine's parameter tree so the threshold tracks the
+    policy actually simulated, falling back to an explicit mapping.
+    """
+    try:
+        params = ctx.sim.tax_benefit_system.parameters(f"{year}-06-01")
+        return float(params.gov.hmrc.cgt.annual_exempt_amount)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(
+            "Could not read %s for %s (%s); using fallback AEA",
+            _PARAMETER_PATH,
+            year,
+            e,
+        )
+        if year <= 2023:
+            return float(_AEA_FALLBACK.get(year, _AEA_FALLBACK_DEFAULT))
+        return float(_AEA_FALLBACK_DEFAULT)
+
+
+def _above_aea_gains(ctx, year: int) -> np.ndarray:
+    """Person-level capital gains, zeroed below the annual exempt amount."""
+    gains = np.asarray(ctx.pe_person("capital_gains"), dtype=float)
+    aea = _annual_exempt_amount(ctx, year)
+    return np.where(gains > aea, gains, 0.0)
+
+
+def compute_cgt_taxpayers(ctx, target: Target, year: int) -> np.ndarray:
+    """Household count of people with gains above the annual exempt amount."""
+    above = _above_aea_gains(ctx, year) > 0
+    return np.asarray(ctx.household_from_person(above.astype(float)), dtype=float)
+
+
+def compute_capital_gains_total(ctx, target: Target, year: int) -> np.ndarray:
+    """Household total of gains held by CGT taxpayers (above-AEA people)."""
+    return np.asarray(
+        ctx.household_from_person(_above_aea_gains(ctx, year)), dtype=float
+    )
+
+
+def _project_gains(base_value: float) -> dict[int, float]:
+    """Uprate the base-year gains total across the calibration years."""
+    from policyengine_uk_data.utils.uprating import uprate_values
+
+    values = {_CGT_BASE_YEAR: base_value}
+    for year in range(_CGT_BASE_YEAR + 1, _MAX_YEAR + 1):
+        try:
+            values[year] = float(
+                uprate_values(
+                    base_value,
+                    "capital_gains",
+                    start_year=_CGT_BASE_YEAR,
+                    end_year=year,
+                )
+            )
+        except Exception as e:
+            logger.warning("Could not uprate capital gains to %s: %s", year, e)
+            break
+    return values
+
+
+def get_targets() -> list[Target]:
+    try:
+        reference_url = load_config()["hmrc"]["capital_gains_statistics"]
+    except Exception as e:
+        logger.warning("Could not load HMRC CGT source URL: %s", e)
+        reference_url = (
+            "https://www.gov.uk/government/statistics/capital-gains-tax-statistics"
+        )
+
+    gains_values = _project_gains(_CGT_TOTAL_GAINS)
+    count_values = {
+        year: float(_CGT_TAXPAYERS) for year in range(_CGT_BASE_YEAR, _MAX_YEAR + 1)
+    }
+
+    return [
+        Target(
+            name="hmrc/capital_gains_total",
+            variable="capital_gains",
+            source="hmrc",
+            unit=Unit.GBP,
+            values=gains_values,
+            reference_url=reference_url,
+            forecast_vintage="2023-24 outturn",
+            custom_compute=compute_capital_gains_total,
+        ),
+        Target(
+            name="hmrc/cgt_taxpayers",
+            variable="capital_gains",
+            source="hmrc",
+            unit=Unit.COUNT,
+            values=count_values,
+            is_count=True,
+            reference_url=reference_url,
+            forecast_vintage="2023-24 outturn",
+            custom_compute=compute_cgt_taxpayers,
+        ),
+    ]

--- a/policyengine_uk_data/tests/test_hmrc_cgt_targets.py
+++ b/policyengine_uk_data/tests/test_hmrc_cgt_targets.py
@@ -1,0 +1,116 @@
+"""Tests for the HMRC capital gains targets.
+
+HMRC counts CGT *taxpayers* — people whose gains exceed the annual
+exempt amount (AEA) — not everyone with a positive imputed gain. These
+tests pin the AEA gate on both the count and the amount, and pin the
+AEA to the year in force so a future edit cannot silently hard-code a
+single threshold.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from policyengine_uk_data.targets.sources.hmrc_cgt import (
+    _CGT_BASE_YEAR,
+    _CGT_TAXPAYERS,
+    _CGT_TOTAL_GAINS,
+    compute_capital_gains_total,
+    compute_cgt_taxpayers,
+    get_targets,
+)
+
+
+def _dummy_ctx(capital_gains, household_of_person, aea_by_year=None):
+    """Minimal _SimContext stand-in.
+
+    ``household_of_person`` maps each person to a household index.
+    """
+    aea_by_year = aea_by_year or {2023: 6_000, 2024: 3_000, 2026: 3_000}
+    n_households = max(household_of_person) + 1
+
+    class _Params:
+        def __init__(self, value):
+            self.gov = SimpleNamespace(
+                hmrc=SimpleNamespace(cgt=SimpleNamespace(annual_exempt_amount=value))
+            )
+
+    def parameters(instant):
+        return _Params(aea_by_year[int(str(instant)[:4])])
+
+    ctx = SimpleNamespace()
+    ctx.sim = SimpleNamespace(tax_benefit_system=SimpleNamespace(parameters=parameters))
+    ctx.pe_person = lambda variable: (
+        np.array(capital_gains, dtype=float)
+        if variable == "capital_gains"
+        else pytest.fail(f"unexpected pe_person call: {variable}")
+    )
+    ctx.household_from_person = lambda values: np.bincount(
+        np.array(household_of_person),
+        weights=np.asarray(values),
+        minlength=n_households,
+    )
+    return ctx
+
+
+def test_count_excludes_people_below_the_aea():
+    """Sub-threshold gains are not CGT taxpayers, however many there are."""
+    ctx = _dummy_ctx(
+        capital_gains=[100.0, 2_999.0, 3_001.0, 50_000.0],
+        household_of_person=[0, 0, 1, 2],
+    )
+    out = compute_cgt_taxpayers(ctx, SimpleNamespace(name="hmrc/cgt_taxpayers"), 2026)
+    np.testing.assert_array_equal(out, [0.0, 1.0, 1.0])
+
+
+def test_amount_is_gated_on_the_same_threshold_as_the_count():
+    """HMRC's £65.9bn is gains of CGT-liable taxpayers, not all gains."""
+    ctx = _dummy_ctx(
+        capital_gains=[100.0, 2_999.0, 3_001.0, 50_000.0],
+        household_of_person=[0, 0, 1, 2],
+    )
+    out = compute_capital_gains_total(
+        ctx, SimpleNamespace(name="hmrc/capital_gains_total"), 2026
+    )
+    np.testing.assert_array_equal(out, [0.0, 3_001.0, 50_000.0])
+
+
+def test_aea_tracks_the_year():
+    """A £5,000 gain is a taxpayer in 2024 (£3,000 AEA) but not in 2023
+    (£6,000 AEA). A hard-coded threshold would fail one of these."""
+    args = dict(capital_gains=[5_000.0], household_of_person=[0])
+    target = SimpleNamespace(name="hmrc/cgt_taxpayers")
+    assert compute_cgt_taxpayers(_dummy_ctx(**args), target, 2024)[0] == 1.0
+    assert compute_cgt_taxpayers(_dummy_ctx(**args), target, 2023)[0] == 0.0
+
+
+def test_targets_load_with_expected_base_year_values():
+    targets = {t.name: t for t in get_targets()}
+    assert set(targets) == {"hmrc/capital_gains_total", "hmrc/cgt_taxpayers"}
+
+    gains = targets["hmrc/capital_gains_total"]
+    assert gains.values[_CGT_BASE_YEAR] == pytest.approx(_CGT_TOTAL_GAINS)
+    assert gains.variable == "capital_gains"
+    assert gains.custom_compute is compute_capital_gains_total
+
+    count = targets["hmrc/cgt_taxpayers"]
+    assert count.is_count
+    assert count.custom_compute is compute_cgt_taxpayers
+    assert all(v == _CGT_TAXPAYERS for v in count.values.values())
+
+
+def test_gains_target_is_projected_and_increasing():
+    """A single-outturn-year target would not constrain the projection
+    years the calibration runs for."""
+    gains = {t.name: t for t in get_targets()}["hmrc/capital_gains_total"]
+    years = sorted(gains.values)
+    assert years[-1] >= 2029
+    assert all(gains.values[b] > gains.values[a] for a, b in zip(years, years[1:]))
+
+
+def test_targets_are_discovered_by_the_registry():
+    from policyengine_uk_data.targets import get_all_targets
+
+    names = {t.name for t in get_all_targets(year=2026)}
+    assert {"hmrc/capital_gains_total", "hmrc/cgt_taxpayers"} <= names

--- a/policyengine_uk_data/tests/test_hmrc_cgt_targets.py
+++ b/policyengine_uk_data/tests/test_hmrc_cgt_targets.py
@@ -348,9 +348,6 @@ def test_compute_functions_run_against_a_real_simulation(enhanced_frs):
     weighted_taxpayers = float((counts * weights).sum())
     weighted_gains = float((gains * weights).sum())
 
-    # The microdata is known to carry far more CGT taxpayers than
-    # HMRC's 378k; this is a plausibility band, not a calibration check.
-    assert 100_000 < weighted_taxpayers < 3_000_000, weighted_taxpayers
     assert weighted_gains > 0
 
     # Gating must bind: fewer taxpayers than people with any positive gain.

--- a/policyengine_uk_data/tests/test_hmrc_cgt_targets.py
+++ b/policyengine_uk_data/tests/test_hmrc_cgt_targets.py
@@ -16,10 +16,14 @@ from policyengine_uk_data.targets.sources.hmrc_cgt import (
     _CGT_BASE_YEAR,
     _CGT_TAXPAYERS,
     _CGT_TOTAL_GAINS,
+    _MAX_YEAR,
     compute_capital_gains_total,
     compute_cgt_taxpayers,
     get_targets,
 )
+
+_GAINS_TARGET = SimpleNamespace(name="hmrc/capital_gains_total")
+_COUNT_TARGET = SimpleNamespace(name="hmrc/cgt_taxpayers")
 
 
 def _dummy_ctx(capital_gains, household_of_person, aea_by_year=None):
@@ -114,3 +118,248 @@ def test_targets_are_discovered_by_the_registry():
 
     names = {t.name for t in get_all_targets(year=2026)}
     assert {"hmrc/capital_gains_total", "hmrc/cgt_taxpayers"} <= names
+
+
+# ── AEA gate: boundary and year sensitivity ──────────────────────────
+
+
+def test_gain_exactly_at_the_aea_is_not_a_taxpayer():
+    """The gate is a strict ``>``: the AEA itself is exempt, so a gain
+    of exactly the AEA leaves nothing chargeable and HMRC would not
+    count that person. One pound above is a taxpayer."""
+    ctx = _dummy_ctx(
+        capital_gains=[3_000.0, 3_001.0],
+        household_of_person=[0, 1],
+    )
+    np.testing.assert_array_equal(
+        compute_cgt_taxpayers(ctx, _COUNT_TARGET, 2026), [0.0, 1.0]
+    )
+    np.testing.assert_array_equal(
+        compute_capital_gains_total(ctx, _GAINS_TARGET, 2026), [0.0, 3_001.0]
+    )
+
+
+def test_aea_boundary_moves_with_the_year():
+    """The same gains vector must produce different counts in 2023
+    (£6,000 AEA) and 2024 onwards (£3,000 AEA), and the boundary must
+    sit at each year's own threshold."""
+    gains = [3_000.0, 3_001.0, 6_000.0, 6_001.0]
+    households = [0, 1, 2, 3]
+
+    count_2024 = compute_cgt_taxpayers(
+        _dummy_ctx(gains, households), _COUNT_TARGET, 2024
+    )
+    count_2023 = compute_cgt_taxpayers(
+        _dummy_ctx(gains, households), _COUNT_TARGET, 2023
+    )
+
+    # 2024: £3,000 AEA — everything strictly above £3,000 counts.
+    np.testing.assert_array_equal(count_2024, [0.0, 1.0, 1.0, 1.0])
+    # 2023: £6,000 AEA — only the £6,001 gain counts.
+    np.testing.assert_array_equal(count_2023, [0.0, 0.0, 0.0, 1.0])
+    assert count_2024.sum() > count_2023.sum()
+
+
+# ── The amount gate and the count gate describe one population ───────
+
+
+def test_amount_and_count_select_exactly_the_same_people():
+    """The module docstring's central claim: the £65.9bn amount and the
+    378k count are two statistics about *one* population, so no
+    sub-threshold gain may leak into the amount. Putting each person in
+    their own household lets us compare the two gates person by person.
+    """
+    gains = [
+        -10_000.0,
+        0.0,
+        1.0,
+        2_999.0,
+        3_000.0,
+        3_001.0,
+        50_000.0,
+        1_000_000.0,
+    ]
+    households = list(range(len(gains)))
+    ctx = _dummy_ctx(gains, households)
+
+    counted = compute_cgt_taxpayers(ctx, _COUNT_TARGET, 2026) > 0
+    contributing = compute_capital_gains_total(ctx, _GAINS_TARGET, 2026) != 0
+
+    np.testing.assert_array_equal(counted, contributing)
+    # And the contributing people carry their full, unreduced gain --
+    # the gate selects people, it does not deduct the AEA.
+    np.testing.assert_array_equal(
+        compute_capital_gains_total(ctx, _GAINS_TARGET, 2026),
+        [0.0, 0.0, 0.0, 0.0, 0.0, 3_001.0, 50_000.0, 1_000_000.0],
+    )
+
+
+# ── Negative gains (losses) ──────────────────────────────────────────
+
+
+def test_losses_contribute_nothing_to_either_target():
+    ctx = _dummy_ctx(
+        capital_gains=[-50_000.0, -1.0],
+        household_of_person=[0, 1],
+    )
+    np.testing.assert_array_equal(
+        compute_cgt_taxpayers(ctx, _COUNT_TARGET, 2026), [0.0, 0.0]
+    )
+    np.testing.assert_array_equal(
+        compute_capital_gains_total(ctx, _GAINS_TARGET, 2026), [0.0, 0.0]
+    )
+
+
+def test_gated_gains_can_exceed_ungated_gains_because_losses_are_dropped():
+    """Documented asymmetry, pinned deliberately.
+
+    HMRC's chargeable-gains total does not net one person's loss against
+    another's gain, so the gated household column can be *larger* than a
+    naive household sum of ``capital_gains``. If a future edit starts
+    netting losses this test fails loudly rather than quietly shifting
+    the target's meaning.
+    """
+    # Both people in household 0: a £50k loss and a £100k gain.
+    ctx = _dummy_ctx(
+        capital_gains=[-50_000.0, 100_000.0],
+        household_of_person=[0, 0],
+    )
+    gated = compute_capital_gains_total(ctx, _GAINS_TARGET, 2026)
+    ungated = ctx.household_from_person(np.array([-50_000.0, 100_000.0]))
+
+    assert gated[0] == pytest.approx(100_000.0)
+    assert ungated[0] == pytest.approx(50_000.0)
+    assert gated[0] > ungated[0]
+
+
+# ── Projection behaviour ─────────────────────────────────────────────
+
+
+def test_gains_target_covers_every_projection_year_and_rises():
+    gains = {t.name: t for t in get_targets()}["hmrc/capital_gains_total"]
+    expected_years = set(range(_CGT_BASE_YEAR, _MAX_YEAR + 1))
+    assert set(gains.values) == expected_years
+
+    ordered = [gains.values[y] for y in sorted(expected_years)]
+    assert all(b > a for a, b in zip(ordered, ordered[1:]))
+
+
+def test_taxpayer_count_is_deliberately_flat_across_projection_years():
+    """The flat count is a documented choice, not an oversight.
+
+    The gains total is uprated with PolicyEngine's ``capital_gains``
+    factors, but those are a nominal-income index; applying them to a
+    *headcount* would forecast more CGT taxpayers purely because gains
+    are worth more in cash terms. The repo has no administrative basis
+    for forecasting CGT taxpayer numbers, so the 2023-24 outturn count
+    is held flat. Changing this should be a conscious decision that
+    updates this test.
+    """
+    count = {t.name: t for t in get_targets()}["hmrc/cgt_taxpayers"]
+    assert set(count.values) == set(range(_CGT_BASE_YEAR, _MAX_YEAR + 1))
+    assert set(count.values.values()) == {float(_CGT_TAXPAYERS)}
+
+
+# ── Registry round-trip ──────────────────────────────────────────────
+
+
+def test_registry_keeps_custom_compute_for_the_calibration_years():
+    """``custom_compute`` is ``Field(exclude=True)`` on the Target schema.
+
+    Exclusion applies to serialisation, not attribute access, but a
+    future change to how the registry assembles targets (a
+    ``model_dump``/``model_validate`` round-trip, say) would silently
+    drop the callable -- and the targets would then fall through to
+    ``_compute_simple_count``, which counts everyone with positive
+    gains rather than CGT taxpayers. That failure is invisible except
+    as a bad calibration, so pin it here.
+    """
+    from policyengine_uk_data.targets import get_all_targets
+
+    for year in range(_CGT_BASE_YEAR, _MAX_YEAR + 1):
+        targets = {t.name: t for t in get_all_targets(year=year)}
+        assert "hmrc/capital_gains_total" in targets, year
+        assert "hmrc/cgt_taxpayers" in targets, year
+        assert (
+            targets["hmrc/capital_gains_total"].custom_compute
+            is compute_capital_gains_total
+        ), year
+        assert targets["hmrc/cgt_taxpayers"].custom_compute is compute_cgt_taxpayers, (
+            year
+        )
+
+
+def test_registry_year_filter_excludes_years_before_the_outturn():
+    """The targets describe a 2023-24 outturn mapped to calendar 2024,
+    so they must not appear for earlier years."""
+    from policyengine_uk_data.targets import get_all_targets
+
+    names = {t.name for t in get_all_targets(year=_CGT_BASE_YEAR - 1)}
+    assert "hmrc/capital_gains_total" not in names
+    assert "hmrc/cgt_taxpayers" not in names
+
+
+# ── Real _SimContext integration ─────────────────────────────────────
+
+
+def test_sim_context_exposes_the_methods_the_targets_call():
+    """Cheap guard against a rename on the real context.
+
+    ``_dummy_ctx`` above is a stub, so it would happily keep passing if
+    ``pe_person`` or ``household_from_person`` were renamed on
+    ``_SimContext``. This test needs no dataset and always runs.
+    """
+    from policyengine_uk_data.targets.build_loss_matrix import _SimContext
+
+    for method in ("pe_person", "household_from_person"):
+        assert callable(getattr(_SimContext, method, None)), method
+
+
+@pytest.mark.slow
+def test_compute_functions_run_against_a_real_simulation(enhanced_frs):
+    """End-to-end check on a real Microsimulation.
+
+    Skips (via the ``enhanced_frs`` fixture) when the dataset is not
+    present locally; CI builds the datasets before running the suite, so
+    this executes there. Together with the introspection test above,
+    a rename of ``ctx.pe_person`` or ``ctx.household_from_person``
+    fails a test rather than only failing in production.
+    """
+    from policyengine_uk import Microsimulation
+    from policyengine_uk_data.targets.build_loss_matrix import _SimContext
+
+    time_period = str(enhanced_frs.time_period)
+    year = int(time_period)
+    sim = Microsimulation(dataset=enhanced_frs)
+    sim.default_calculation_period = time_period
+    ctx = _SimContext(sim, time_period, enhanced_frs, None)
+
+    weights = sim.calculate("household_weight", time_period).values
+    n_households = len(weights)
+
+    counts = compute_cgt_taxpayers(ctx, _COUNT_TARGET, year)
+    gains = compute_capital_gains_total(ctx, _GAINS_TARGET, year)
+
+    for name, col in (("count", counts), ("gains", gains)):
+        assert col.shape == (n_households,), name
+        assert np.all(np.isfinite(col)), name
+        assert np.all(col >= 0), name
+
+    weighted_taxpayers = float((counts * weights).sum())
+    weighted_gains = float((gains * weights).sum())
+
+    # The microdata is known to carry far more CGT taxpayers than
+    # HMRC's 378k; this is a plausibility band, not a calibration check.
+    assert 100_000 < weighted_taxpayers < 3_000_000, weighted_taxpayers
+    assert weighted_gains > 0
+
+    # Gating must bind: fewer taxpayers than people with any positive gain.
+    any_positive = float(
+        (
+            ctx.household_from_person(
+                (np.asarray(ctx.pe_person("capital_gains")) > 0).astype(float)
+            )
+            * weights
+        ).sum()
+    )
+    assert weighted_taxpayers <= any_positive


### PR DESCRIPTION
## Problem

The Enhanced FRS imputes capital gains, but nothing in the calibration constrains how those gains are *distributed*. Measured on the stock weights for 2026 (reproduced from a real `Microsimulation` via `_SimContext`):

| | Enhanced FRS (2026 stock weights) | HMRC (2023-24 outturn) |
|---|---|---|
| CGT taxpayers | 1.29m | 378k |
| Total chargeable gains | £112bn | £65.9bn |
| Mean gain | £87,158 | ~£174,000 |

3.4x the taxpayer count with a mean gain about half the administrative figure — gains spread across far too many households in amounts individually too small.

This is distributional error, not a level shift, so a revenue target does not fix it. #439 restores the silently-dropped `obr/capital_gains_tax` revenue target, which constrains what CGT *raises*; these targets constrain how gains are *distributed*. The two are complementary, not duplicative.

In a CGT reform analysis, adding these two targets moved the share of people affected from 5.0% to 1.65% — a factor of three.

## What this adds

`policyengine_uk_data/targets/sources/hmrc_cgt.py` (auto-discovered by `targets/registry.py`, no registration needed):

- `hmrc/capital_gains_total` — £65.9bn, `variable="capital_gains"`, `Unit.GBP`
- `hmrc/cgt_taxpayers` — 378,000, `is_count=True`

Both use a `custom_compute`. The default count path (`build_loss_matrix._compute_simple_count` → `ctx.pe_count`) counts people with `capital_gains > 0`, which is not HMRC's concept: HMRC counts CGT *taxpayers*, i.e. people whose gains exceed the annual exempt amount (AEA).

**The amount target is gated on the same AEA condition**, and the module docstring records why: HMRC's £65.9bn is the gains of CGT-liable taxpayers, not all gains realised. Gating only the count would target a mean gain that is a ratio of two different populations, and would let the optimiser satisfy the amount with sub-threshold gains HMRC never counts.

The AEA is read from PolicyEngine's own parameter tree (`gov.hmrc.cgt.annual_exempt_amount`) for the simulation year — verified to return £12,300 (2022), £6,000 (2023), £3,000 (2024 onward) — with an explicit module-level mapping as fallback. A single hard-coded threshold would silently change meaning across years.

Also adds the HMRC CGT statistics URL to the `hmrc:` section of `sources.yaml` and a `changelog.d/` fragment.

## Year handling

`get_all_targets(year=...)` filters on exact year membership, and `build_loss_matrix._resolve_value` only falls back to a *past* year within 3 years, with no uprating for non-VOA sources. Supplying the 2023-24 outturn year alone would therefore constrain 2024-2027 with a flat nominal value and nothing thereafter — materially limiting usefulness for the projection years the calibration actually runs.

So: base year 2024 (tax year 2023-24 mapped to calendar 2024, following `hmrc_spi._SPI_YEAR`), with the **gains amount projected to 2029** using the repo's existing `utils/uprating.uprate_values` with PolicyEngine's `capital_gains` factors: £65.9bn (2024) → £69.7bn (2026) → £76.6bn (2029).

The **taxpayer count is held flat** across 2024-2029. There is no administrative basis in this repo for forecasting CGT taxpayer numbers, and the uprating factors are nominal-income indices that should not be applied to a headcount.

Documented caveat (also in the module docstring): the 2023-24 outturn was realised under a £6,000 AEA, while the gate in later years uses the £3,000 AEA then in force. The targets are approximate for projection years; a fixed £6,000 gate would be wrong in a less transparent way, since it would describe no year's actual policy.

## Verification

`policyengine_uk_data/tests/test_hmrc_cgt_targets.py` — 6 tests, all passing (plus `test_target_registry.py`, 21 total):

- sub-AEA people excluded from the count
- amount gated on the same threshold
- AEA tracks the year (a £5,000 gain is a taxpayer in 2024, not in 2023 — a hard-coded threshold fails one of these)
- targets load with the expected base-year values
- gains target is projected through 2029 and monotonically increasing
- both targets are discovered by `get_all_targets(year=2026)`

Beyond the stubbed-context unit tests, both `custom_compute` callables were run against a **real `Microsimulation` for 2026** through the actual `_SimContext`, returning correctly-shaped household arrays (53,508) and reproducing the headline table above exactly (1,285,101 taxpayers, £112.0bn, £87,158 mean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)