### PR TITLE
Narrow national gender x age targets to five-year bands (unblocks publishing)

### DIFF
--- a/changelog.d/national-age-bands.md
+++ b/changelog.d/national-age-bands.md
@@ -1,0 +1,1 @@
+- Narrow the national gender x age calibration targets from 15-year to five-year bands. The wide bands pinned only their own totals, leaving age composition inside them unconstrained nationally, which collapsed the modelled 18-24 population to ~3.4M against ONS's ~5.4M. Also skip the superseded 15-year rows in `demographics.csv` so the two sets cannot double-count.

--- a/policyengine_uk_data/targets/sources/ons_demographics.py
+++ b/policyengine_uk_data/targets/sources/ons_demographics.py
@@ -65,13 +65,32 @@ _AGE_BANDS = [
     (80, 89),
 ]
 
+# Five-year bands. The previous 15-year bands (0-14, 15-29, ...) pinned only
+# the band totals, leaving the age composition *within* a band unconstrained
+# nationally: the calibration could satisfy 15-29 while starving 18-24, which
+# is what collapsed the modelled young-adult population to ~3.4M against ONS's
+# ~5.4M. Regional targets already use finer bands, but they do not constrain
+# the national weights. The ONS projection is published by single year of age,
+# so this is a change of aggregation only - no new source data.
 _GENDER_BANDS = [
-    (0, 14),
-    (15, 29),
-    (30, 44),
-    (45, 59),
-    (60, 74),
-    (75, 90),
+    (0, 4),
+    (5, 9),
+    (10, 14),
+    (15, 19),
+    (20, 24),
+    (25, 29),
+    (30, 34),
+    (35, 39),
+    (40, 44),
+    (45, 49),
+    (50, 54),
+    (55, 59),
+    (60, 64),
+    (65, 69),
+    (70, 74),
+    (75, 79),
+    (80, 84),
+    (85, 90),
 ]
 
 
@@ -186,7 +205,11 @@ def _parse_regional_from_csv() -> list[Target]:
 
     # Skip rows now handled by dedicated modules (ons_households.py,
     # ons_tenure.py) and rows handled elsewhere in this module
-    _SKIP_PREFIXES = ("tenure_", "scotland_households")
+    # female_/male_ rows in demographics.csv are the superseded 15-year gender
+    # bands. The live ONS projection now supplies five-year bands under the
+    # same naming scheme, so emitting the CSV rows as well would double-count
+    # the population and constrain overlapping ranges against each other.
+    _SKIP_PREFIXES = ("tenure_", "scotland_households", "female_", "male_")
     _SKIP_NAMES = {
         "couple_3_plus_children_households",
         "couple_no_children_households",

--- a/policyengine_uk_data/tests/test_national_age_bands.py
+++ b/policyengine_uk_data/tests/test_national_age_bands.py
@@ -1,0 +1,62 @@
+"""National age-band granularity tests.
+
+The national gender x age targets previously used 15-year bands (0-14,
+15-29, ...). A band that wide pins only its own total: the calibration could
+satisfy 15-29 while distributing those people any way it liked inside the
+band, and it settled on one that starved 18-24 down to ~3.4M against ONS's
+~5.4M. The finer regional bands do not help, because they constrain regional
+weights rather than the national ones.
+
+These tests pin the five-year granularity and the no-overlap property, so a
+future edit cannot quietly widen the bands or reintroduce the superseded CSV
+rows alongside them.
+"""
+
+import re
+
+from policyengine_uk_data.targets.sources.ons_demographics import (
+    _GENDER_BANDS,
+    get_targets,
+)
+
+_GENDER_AGE = re.compile(r"^ons/(female|male)_(\d+)_(\d+)$")
+
+
+def _gender_age_targets():
+    return [t for t in get_targets() if _GENDER_AGE.match(t.name)]
+
+
+def test_bands_are_at_most_five_years_wide():
+    """A wider band leaves its internal age composition unconstrained."""
+    for low, high in _GENDER_BANDS:
+        assert high - low <= 5, f"band {low}-{high} is too wide to pin composition"
+
+
+def test_bands_are_contiguous_and_non_overlapping():
+    """Overlapping bands would double-count the population."""
+    ordered = sorted(_GENDER_BANDS)
+    for (_, prev_high), (next_low, _) in zip(ordered, ordered[1:]):
+        assert next_low == prev_high + 1, f"gap or overlap at {prev_high}/{next_low}"
+
+
+def test_young_adult_ages_are_covered_by_narrow_bands():
+    """18-24 must not sit inside one wide band, which is the failure mode."""
+    covering = [b for b in _GENDER_BANDS if b[0] <= 24 and b[1] >= 18]
+    assert len(covering) >= 2, (
+        "18-24 is covered by a single band; its composition would be free"
+    )
+
+
+def test_national_gender_age_targets_are_emitted_once_per_band():
+    """The superseded 15-year CSV rows must not be emitted alongside these."""
+    targets = _gender_age_targets()
+    assert len(targets) == len(_GENDER_BANDS) * 2
+    assert len({t.name for t in targets}) == len(targets)
+
+
+def test_national_gender_age_targets_sum_to_uk_population():
+    """Double-counted bands would show up here as a doubled total."""
+    targets = _gender_age_targets()
+    year = 2025
+    total = sum(t.values.get(year, 0) for t in targets)
+    assert 65e6 < total < 73e6, f"national gender-age total {total / 1e6:.1f}M"


### PR DESCRIPTION
Fixes #441.

## Problem

Publishing has been blocked since 19 June: every `push.yaml` run fails at `test_population_fidelity.py::test_young_adult_population_not_collapsed`, so the workflow never reaches `make upload`. No UK dataset has published for a month.

The national gender x age targets used **15-year bands**:

```
0-14: 11.6M   15-29: 12.86M   30-44: 14.15M   45-59: 13.08M   60-74: 11.16M   75-90: 6.16M
```

18-24 sits entirely inside 15-29. A band that wide pins only its own total — calibration can satisfy 12.86M while distributing those people any way it likes inside the band, and it settles on ~3.4M in 18-24 (26% of the band) where ONS implies ~5.4M (42%). Total population passes at 69.1M because the missing 2M are absorbed into other bands; the error is compositional.

The finer 10-year bands do not help: all 108 `..._age_X_Y` targets are `REGION`-level and constrain regional weights, not national ones. The national set had no age constraint narrower than 15 years.

## Why this is the cause rather than a corrupting stage

Two builds with very different inputs converge on the same wrong answer:

| Input | raw 18-24 | final 18-24 |
|---|---|---|
| Scrambled weights (pre-#436 published build) | 2.98M | 3.48M |
| Healthy weights (post-#436, rebuilt from source) | 5.32M | ~3.44M (CI) |

A stage that corrupted the data would produce output tracking its input. Converging to ~3.4M from both 2.98M and 5.32M is what an unconstrained dimension looks like.

## Change

Narrows `_GENDER_BANDS` to five-year bands. The ONS projection is published by single year of age and `_aggregate_ages` already sums arbitrary ranges, so this is a change of aggregation only — no new source data, no new download.

Also adds `female_`/`male_` to `_SKIP_PREFIXES` for `demographics.csv`. That file hardcodes the superseded 15-year rows; without the skip they are emitted alongside the new five-year bands under a non-colliding naming scheme, double-counting the population. Verified: **138.6M before the skip, 69.0M after**, against ONS ~69.5M.

## Verification

After the change, 36 national targets across 18 contiguous five-year bands:

```
0-4 3.48M   5-9 3.93M   10-14 4.19M   15-19 4.19M   20-24 4.17M   25-29 4.50M
...
TOTAL 69.0M   (ONS ~69.5M)
```

20-24 is now pinned in its own band, and 18-24 straddles only two narrow bands instead of sitting inside one wide one.

Five tests pin the properties that matter: bands at most five years wide, contiguous and non-overlapping, 18-24 covered by more than one band, one target per band per sex (catching reintroduction of the CSV rows), and the national total in a sane range (catching double-counting).

## What this does not claim

I have not run a full post-change build to confirm 18-24 lands near 5.4M — that needs CI. The prediction is explicit and falsifiable: if the guard still fails after this, the wide bands were not the binding constraint and the diagnosis in #441 is wrong.

## Related

- **#436** fixed a real scrambled-weights bug in the 2024-25 FRS ingestion, and is verified working (rebuilding raw from source restores corr(weight, size) to +0.226 and 18-24 to 5.32M). It has never been published, because the guard it added has blocked every release since.
- **`ni_class_2` / `ni_class_4`** OBR targets are also silently dropped on label-match failure, the same pattern #439 fixed for cash receipts. Not addressed here.
